### PR TITLE
ci: run downstream only on changes in src and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - 'develop'
     tags-ignore:
       - '**'
+    paths:
+      - "src/**"
+      - "tests/**"
 
   # Trigger the workflow on pull request
   pull_request: ~


### PR DESCRIPTION
Filter for changes in src and tests folder to avoid running the downstream-ci pipeline for changes not related to source code or tests.