### PR TITLE
Hotfix/resolve packages distributions not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Keep it human-readable, your future self will thank you!
 - Docsig precommit hooks
 - Changelog merge strategy- Codeowners file
 - Create dependency on wcwidth. MIT licence.
-- Add distribution name dictionary to provenance [#15](https://github.com/ecmwf/anemoi-utils/pull/15)
+- Add distribution name dictionary to provenance [#15](https://github.com/ecmwf/anemoi-utils/pull/15) & [#19](https://github.com/ecmwf/anemoi-utils/pull/19)
 - Add anonimize() function.
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,10 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
   "aniso8601",
+  "importlib-metadata; python_version<'3.10'",
+
   "pyyaml",
-  "tomli",     # Only needed before 3.11
+  "tomli",  # Only needed before 3.11
   "tqdm",
 ]
 

--- a/src/anemoi/utils/provenance.py
+++ b/src/anemoi/utils/provenance.py
@@ -148,38 +148,13 @@ def _module_versions(full):
 def package_distributions() -> dict[str, list[str]]:
     # Takes a significant amount of time to run
     # so cache the result
-    import collections
     from importlib import metadata
 
     # For python 3.9 support
-    # Copy of importlib.metadata.packages_distributions()
+    if not hasattr(metadata, "packages_distributions"):
+        import importlib_metadata as metadata
 
-    def packages_distributions():
-        """Return a mapping of top-level packages to their
-        distributions.
-
-        >>> import collections.abc
-        >>> pkgs = packages_distributions()
-        >>> all(isinstance(dist, collections.abc.Sequence) for dist in pkgs.values())
-        True
-        """
-        pkg_to_dist = collections.defaultdict(list)
-        for dist in metadata.distributions():
-            for pkg in _top_level_declared(dist) or _top_level_inferred(dist):
-                pkg_to_dist[pkg].append(dist.metadata["Name"])
-        return dict(pkg_to_dist)
-
-    def _top_level_declared(dist):
-        return (dist.read_text("top_level.txt") or "").split()
-
-    def _top_level_inferred(dist):
-        return {
-            f.parts[0] if len(f.parts) > 1 else f.with_suffix("").name
-            for f in (dist.files if isinstance(dist.files, (tuple, list)) else [dist.files])
-            if f.suffix == ".py"
-        }
-
-    return packages_distributions()
+    return metadata.packages_distributions()
 
 
 def import_name_to_distribution_name(packages: list):

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,14 @@
+# (C) Copyright 2024 European Centre for Medium-Range Weather Forecasts.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+from anemoi.utils import provenance
+
+
+def test_gather():
+    """Test success of gather_provenance_info"""
+    provenance.gather_provenance_info()


### PR DESCRIPTION
packages distributions is not available in python 3.9

This hotfix addresses this issue