### PR TITLE
make-sanitise-string-less-global

### DIFF
--- a/src/anemoi/utils/sanitise.py
+++ b/src/anemoi/utils/sanitise.py
@@ -45,7 +45,7 @@ def _sanitise_string(obj):
 
     parsed = urlparse(obj, allow_fragments=True)
 
-    if parsed.scheme:
+    if parsed.scheme and parsed.scheme[0].isalpha():
         return _sanitise_url(parsed)
 
     if obj.startswith("/") or obj.startswith("~"):


### PR DESCRIPTION
This is to because on mac-os, `sanitise("2021-01-03T12:00:00")` was treating the string as a url and returning "2021-01-03t12:00:00"  (with lowercase 't')