### PR TITLE
Optional naming of subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Keep it human-readable, your future self will thank you!
 
 ## [Unreleased](https://github.com/ecmwf/anemoi-utils/compare/0.4.1...HEAD)
 
+### Added
+- Optional renaming of subcommands via `name` attribute [#34](https://github.com/ecmwf/anemoi-utils/pull/34)
+
 ## [0.4.1](https://github.com/ecmwf/anemoi-utils/compare/0.4.0...0.4.1) - 2024-10-23
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Keep it human-readable, your future self will thank you!
 ## [Unreleased](https://github.com/ecmwf/anemoi-utils/compare/0.4.1...HEAD)
 
 ### Added
-- Optional renaming of subcommands via `name` attribute [#34](https://github.com/ecmwf/anemoi-utils/pull/34)
+- Optional renaming of subcommands via `command` attribute [#34](https://github.com/ecmwf/anemoi-utils/pull/34)
 
 ## [0.4.1](https://github.com/ecmwf/anemoi-utils/compare/0.4.0...0.4.1) - 2024-10-23
 

--- a/src/anemoi/utils/cli.py
+++ b/src/anemoi/utils/cli.py
@@ -97,6 +97,8 @@ def register_commands(here, package, select, fail=None):
 
         obj = select(imported)
         if obj is not None:
+            if hasattr(obj, "name"):
+                name = obj.name
             result[name] = obj
 
     for name, e in not_available.items():

--- a/src/anemoi/utils/cli.py
+++ b/src/anemoi/utils/cli.py
@@ -97,8 +97,8 @@ def register_commands(here, package, select, fail=None):
 
         obj = select(imported)
         if obj is not None:
-            if hasattr(obj, "name"):
-                name = obj.name
+            if hasattr(obj, "command"):
+                name = obj.command
             result[name] = obj
 
     for name, e in not_available.items():

--- a/src/anemoi/utils/cli.py
+++ b/src/anemoi/utils/cli.py
@@ -102,6 +102,13 @@ def register_commands(here, package, select, fail=None):
         if hasattr(obj, "command"):
             name = obj.command
 
+        if name in result:
+            msg = f"Duplicate command '{name}', please choose a different command name for {type(obj)}"
+            raise ValueError(msg)
+        if " " in name:
+            msg = f"Commands cannot contain spaces: '{name}' in {type(obj)}"
+            raise ValueError(msg)
+
         result[name] = obj
 
     for name, e in not_available.items():

--- a/src/anemoi/utils/cli.py
+++ b/src/anemoi/utils/cli.py
@@ -96,10 +96,13 @@ def register_commands(here, package, select, fail=None):
             continue
 
         obj = select(imported)
-        if obj is not None:
-            if hasattr(obj, "command"):
-                name = obj.command
-            result[name] = obj
+        if obj is None:
+            continue
+
+        if hasattr(obj, "command"):
+            name = obj.command
+
+        result[name] = obj
 
     for name, e in not_available.items():
         if fail is None:


### PR DESCRIPTION
This PR allows subcommands to have a different name than their file name via an optional attribute `command`

Usage:

```python
# commands/mycommand.py
class MyCommand(Command):
   command = "fancy-command"
```

Will then become `anemoi-package fancy-command` instead of `anemoi-package mycommand`

If the `command` attribute is not present in the class, the filename is used. I suggest we use that as the default, and only add a `command` if an explicit rename is required.