### PR TITLE
Add a skip_on_hpc pytest marker

### DIFF
--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -5,4 +5,4 @@ build:
   parallel: 64
 
   pytest_cmd: |
-    python -m pytest -vv -m 'not notebook and not no_cache_init' --cov=. --cov-report=xml
+    python -m pytest -vv -m 'not notebook and not no_cache_init and not skip_on_hpc' --cov=. --cov-report=xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Keep it human-readable, your future self will thank you!
 
 ### Added
 - Optional renaming of subcommands via `command` attribute [#34](https://github.com/ecmwf/anemoi-utils/pull/34)
+- `skip_on_hpc` pytest marker for tests that should not be run on HPC [36](https://github.com/ecmwf/anemoi-utils/pull/36)
 
 ## [0.4.1](https://github.com/ecmwf/anemoi-utils/compare/0.4.0...0.4.1) - 2024-10-23
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,3 +82,8 @@ scripts.anemoi-utils = "anemoi.utils.__main__:main"
 
 [tool.setuptools_scm]
 version_file = "src/anemoi/utils/_version.py"
+
+[tool.pytest.ini_options]
+markers = [
+  "skip_on_hpc: mark a test that should not be run on HPC",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    skip_on_hpc: marks tests that should not be run on HPC (deselect with '-m "not skip_on_hpc"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    skip_on_hpc: marks tests that should not be run on HPC (deselect with '-m "not skip_on_hpc"')


### PR DESCRIPTION
Adds the `skip_on_hpc` pytest marker, and deselects it in the pytest command that is run on the HPC.

Tests can then be skipped by doing:

```python

@pytest.mark.skip_on_hpc
def test_something():
    # will skip on HPC
    pass
````