### PR TITLE
chore: Update CHANGELOG Requirements

### DIFF
--- a/.github/workflows/changelog-pr-update.yml
+++ b/.github/workflows/changelog-pr-update.yml
@@ -1,18 +1,18 @@
-name: Check Changelog Update on PR
-on:
-  pull_request:
-    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
-    branches:
-      - main
-      - develop
-    paths-ignore:
-      - .pre-commit-config.yaml
-      - .readthedocs.yaml
-jobs:
-  Check-Changelog:
-    name: Check Changelog Action
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: tarides/changelog-check-action@v2
-        with:
-          changelog: CHANGELOG.md
+# name: Check Changelog Update on PR
+# on:
+#   pull_request:
+#     types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+#     branches:
+#       - main
+#       - develop
+#     paths-ignore:
+#       - .pre-commit-config.yaml
+#       - .readthedocs.yaml
+# jobs:
+#   Check-Changelog:
+#     name: Check Changelog Action
+#     runs-on: ubuntu-20.04
+#     steps:
+#       - uses: tarides/changelog-check-action@v2
+#         with:
+#           changelog: CHANGELOG.md

--- a/.github/workflows/changelog-release-update.yml
+++ b/.github/workflows/changelog-release-update.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         latest-version: ${{ github.event.release.tag_name }}
         heading-text: ${{ github.event.release.name }}
+        release-notes: ${{ github.event.release.body }}
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
# Testing new CHANGELOG process

### Reasoning
`utils` will no longer require every PR to add to the changelog, in fact they should not. 
Instead the PR title will be used in the release log and edited by the release manager. 

These notes will then be included in the changelog in a PR to develop.

### Updates

- No longer require changelog updates
- Autoupdate Changelog on release

If this PR is to be reverted in the future, the changelog can be easily reconstructed.