### PR TITLE
Triggers, messaging, release notes in changelog CI

### DIFF
--- a/.github/workflows/changelog-release-update.yml
+++ b/.github/workflows/changelog-release-update.yml
@@ -2,9 +2,11 @@
 name: "Update Changelog"
 
 on:
-  release:
-    types: [released]
-  workflow_dispatch: ~
+  workflow_run:
+    workflows:
+      - Upload Python Package
+    types:
+      - completed
 
 permissions:
   pull-requests: write
@@ -13,12 +15,13 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: develop
+        ref: ${{ github.event.release.target_commitish }}
 
     - name: Update Changelog
       uses: stefanzweifel/changelog-updater-action@v1
@@ -31,6 +34,12 @@ jobs:
       uses: peter-evans/create-pull-request@v6
       with:
         branch: docs/changelog-update-${{ github.event.release.tag_name }}
+        base: develop
         title: '[Changelog] Update to ${{ github.event.release.tag_name }}'
+        body: |
+          This PR updates the changelog to include the changes in the latest release.
+
+          > [!CAUTION]
+          > Merge DO NOT squash to correctly update the tag version of `develop` branch.
         add-paths: |
           CHANGELOG.md


### PR DESCRIPTION
1. Changes when the CI is run.

This avoids "bad runs" if a release fails, as it depends on a successful workflow run.

2. Copies the generated release note to the changelog

This intends to reduce merge conflicts due to individually updated changelogs.

3. Big red message in PR to merge

This adds a note to the PR message to not squash to help users perform the correct action.