### PR TITLE
Feature request: Add option to read configuration from stdin

### DIFF
--- a/src/anemoi/utils/config.py
+++ b/src/anemoi/utils/config.py
@@ -208,6 +208,7 @@ def load_any_dict_format(path) -> dict:
 
         if path == "-":
             import sys
+
             config = sys.stdin.read()
 
             parsers = [(yaml.safe_load, "yaml"), (json.loads, "json"), (tomllib.loads, "toml")]
@@ -216,10 +217,10 @@ def load_any_dict_format(path) -> dict:
                 try:
                     LOG.debug(f"Trying {parser_type} parser for stdin")
                     return parser(config)
-                except Exception as e:
+                except Exception:
                     pass
 
-            raise ValueError(f"Failed to parse configuration from stdin")
+            raise ValueError("Failed to parse configuration from stdin")
 
     except (json.JSONDecodeError, yaml.YAMLError, tomllib.TOMLDecodeError) as e:
         LOG.warning(f"Failed to parse config file {path}", exc_info=e)


### PR DESCRIPTION
If configuration filename is a hyphen "-", we attempt to parse the input from stdin. This makes it possible to modify configuration files with linux command line tools and pipe the results to (for example) "anemoi-dataset create". Both linux pipes and input redirection is supported.

cat config.yaml | anemoi-datasets create - test.zarr 
anemoi-datasets create - test.zarr < config.yaml

We attempt to read the contents using the supported parsers in the following order: yaml, json, toml.

If all parsers fail, an exception is raised.