### PR TITLE
Add requests command for json to mars format

### DIFF
--- a/src/anemoi/utils/commands/requests.py
+++ b/src/anemoi/utils/commands/requests.py
@@ -1,0 +1,44 @@
+# (C) Copyright 2024 European Centre for Medium-Range Weather Forecasts.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import json
+
+from anemoi.utils.mars.requests import print_request
+
+from . import Command
+
+
+class Requests(Command):
+    """Convert a JSON requests file to MARS format."""
+
+    def add_arguments(self, command_parser):
+        command_parser.add_argument("input")
+        command_parser.add_argument("output")
+        command_parser.add_argument("--verb", default="retrieve")
+        command_parser.add_argument("--only-one-field", action="store_true")
+
+    def run(self, args):
+        with open(args.input) as f:
+            requests = json.load(f)
+
+        if args.only_one_field:
+            for r in requests:
+                for key in (
+                    "grid",
+                    "area",
+                ):
+                    r.pop(key, None)
+                for k, v in list(r.items()):
+                    if isinstance(v, list):
+                        r[k] = v[-1]
+
+        with open(args.output, "w") as f:
+            for r in requests:
+                print_request(args.verb, r, file=f)
+
+
+command = Requests

--- a/src/anemoi/utils/mars/requests.py
+++ b/src/anemoi/utils/mars/requests.py
@@ -1,0 +1,22 @@
+# (C) Copyright 2024 European Centre for Medium-Range Weather Forecasts.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import sys
+
+
+def print_request(verb, request, file=sys.stdout):
+    r = [verb]
+    for k, v in request.items():
+        if not isinstance(v, (list, tuple, set)):
+            v = [v]
+        v = [str(_) for _ in v]
+        v = "/".join(v)
+        r.append(f"{k}={v}")
+
+    r = ",\n   ".join(r)
+    print(r, file=file)
+    print(file=file)


### PR DESCRIPTION
As the title says. Takes an input requests file in json format and outputs a mars request.

Example:

```
anemoi-utils requests input.json output.req --verb archive
```