### PR TITLE
fix: add optional dependency. boto3 <= 1.36

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,12 @@ dependencies = [
   "tqdm",
 ]
 
-optional-dependencies.all = [ "anemoi-utils[grib,provenance,text]" ]
+optional-dependencies.all = [ "anemoi-utils[grib,provenance,text,s3]" ]
 optional-dependencies.dev = [ "anemoi-utils[all,docs,tests]" ]
+
+optional-dependencies.s3 = [
+  "boto3<1.36",
+]
 
 optional-dependencies.docs = [
   "nbsphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,10 +52,6 @@ dependencies = [
 optional-dependencies.all = [ "anemoi-utils[grib,provenance,text,s3]" ]
 optional-dependencies.dev = [ "anemoi-utils[all,docs,tests]" ]
 
-optional-dependencies.s3 = [
-  "boto3<1.36",
-]
-
 optional-dependencies.docs = [
   "nbsphinx",
   "pandoc",
@@ -69,6 +65,10 @@ optional-dependencies.docs = [
 optional-dependencies.grib = [ "requests" ]
 
 optional-dependencies.provenance = [ "gitpython", "nvsmi" ]
+
+optional-dependencies.s3 = [
+  "boto3<1.36",
+]
 
 optional-dependencies.tests = [ "pytest" ]
 


### PR DESCRIPTION
Set boto3 version to avoid https://stackoverflow.com/questions/79375793/s3uploadfailederror-due-to-missingcontentlength-when-calling-putobject-in-mlflow

Then the dependecy to boto3 in anemoi-registry should be removed and replaced by a dependency to anemoi-utils[s3].