### PR TITLE
fix: keep yaml formating in error messages

### DIFF
--- a/src/anemoi/utils/text.py
+++ b/src/anemoi/utils/text.py
@@ -157,7 +157,7 @@ def boxed(text: str, min_width: int = 80, max_width: int = 80) -> str:
 
     lines = []
     for line in text.split("\n"):
-        line = line.strip()
+        line = line.rstrip()
         line = _split_tokens(line)
         lines.append(line)
 


### PR DESCRIPTION
## Description

This keeps some space in the boxed texts.

When calling

`boxed(  {"input_patches": [{"substitute": [{"param": ["sdor", "slor"]}, {"type": "cf"}]}]},)`

Before this change (indentation is lost):
```


┌──────────────────────────────────────────────────────────────────────────────────┐
│ input_patches:                                                                   │
│ - substitute:                                                                    │
│ - param:                                                                         │
│ - sdor                                                                           │
│ - slor                                                                           │
│ - type: cf                                                                       │
└──────────────────────────────────────────────────────────────────────────────────┘

```
After this change (indentation is kept)

```
┌──────────────────────────────────────────────────────────────────────────────────┐
│ input_patches:                                                                   │
│ - substitute:                                                                    │
│   - param:                                                                       │
│     - sdor                                                                       │
│     - slor                                                                       │
│   - type: cf                                                                     │
└──────────────────────────────────────────────────────────────────────────────────┘
```
