### PR TITLE
fix: Iterate over copy of sys.modules.

### DIFF
--- a/src/anemoi/utils/provenance.py
+++ b/src/anemoi/utils/provenance.py
@@ -199,12 +199,12 @@ def _module_versions(full: bool) -> Tuple[Dict[str, Any], set]:
 
     versions = {}
     namespaces = set()
-    for k, v in sorted(sys.modules.items()):
+    for k, v in sorted(sys.modules.copy().items()):
         if "." not in k:
             version(versions, k, v, roots, namespaces, paths, full)
 
     # Catter for modules like "earthkit.meteo"
-    for k, v in sorted(sys.modules.items()):
+    for k, v in sorted(sys.modules.copy().items()):
         bits = k.split(".")
         if len(bits) == 2 and bits[0] in namespaces:
             version(versions, k, v, roots, namespaces, paths, full)


### PR DESCRIPTION
## Description

Iterate over copy of sys.modules instead of directly. See https://github.com/ecmwf/anemoi-utils/issues/126

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Closes #126

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass

I got lots of errors, but they seem to be related to credentials for an s3 storage.

========================================== 8 failed, 151 passed, 1 warning in 8.40s ===========================================

### Dependencies

-   [] I have ensured that the code is still pip-installable after the changes and runs
-   [] I have tested that new dependencies themselves are pip-installable.

### Documentation

-   [x] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

## Additional Notes
