### PR TITLE
fix: remove archive file after unpacking

### DIFF
--- a/src/anemoi/utils/testing.py
+++ b/src/anemoi/utils/testing.py
@@ -157,6 +157,8 @@ def get_test_archive(path: str, extension=".extracted") -> str:
         shutil.unpack_archive(archive, os.path.dirname(target) + ".tmp")
         os.rename(os.path.dirname(target) + ".tmp", target)
 
+        os.remove(archive)
+
         return target
 
 


### PR DESCRIPTION
## Description

In get_test_archive from the testing utilities, remove the archive file after unpacking it. This fixes a problem in integration tests where the collection of temporary files exceeded disk quota after several tests. Compare https://github.com/ecmwf/anemoi-core/pull/217

Issue: In the integration tests, we remove the directory containing the unpacked archive after each test but don't have the dir name for the folder containing the archive file itself (to clean this up as well). After a few integration tests, the collection of temporary archive files exceeds the disk quota.

Solution: This PR removes the archive file after unpacking it. I.e. we clean up in between tests and not just at the end of pytest.

Alternative: return both paths (to archive and unpacked archive) such that they can be cleaned up at the end of each integration test.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update


## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [x] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass
