### PR TITLE
fix: do not write to existing dir

### DIFF
--- a/src/anemoi/utils/testing.py
+++ b/src/anemoi/utils/testing.py
@@ -156,10 +156,11 @@ def get_test_archive(path: str, extension=".extracted") -> str:
         archive = get_test_data(path)
         target = archive + extension
 
+        if os.path.exists(target):
+            return target
+
         shutil.unpack_archive(archive, os.path.dirname(target) + ".tmp")
         os.rename(os.path.dirname(target) + ".tmp", target)
-
-        os.remove(archive)
 
         return target
 

--- a/src/anemoi/utils/testing.py
+++ b/src/anemoi/utils/testing.py
@@ -68,6 +68,23 @@ def _check_path(path: str) -> None:
     assert not path.startswith("."), f"Path '{path}' should not start with '.'"
 
 
+def _temporary_directory_for_test_data(path: str) -> str:
+    """Get the temporary directory for a test dataset.
+
+    Parameters
+    ----------
+    path : str
+        The relative path to the test data in the object store.
+
+    Returns
+    -------
+    str
+        The path to the temporary directory.
+    """
+    _check_path(path)
+    return os.path.normpath(os.path.join(_temporary_directory(), path))
+
+
 def url_for_test_data(path: str) -> str:
     """Generate the URL for the test data based on the given path.
 
@@ -101,12 +118,11 @@ def get_test_data(path: str, gzipped=False) -> str:
     str
         The local path to the downloaded test data.
     """
-    _check_path(path)
 
     if _offline():
         raise RuntimeError("Offline mode: cannot download test data, add @pytest.mark.skipif(not offline(),...)")
 
-    target = os.path.normpath(os.path.join(_temporary_directory(), path))
+    target = _temporary_directory_for_test_data(path)
     with lock:
         if os.path.exists(target):
             return target
@@ -153,14 +169,17 @@ def get_test_archive(path: str, extension=".extracted") -> str:
 
     with lock:
 
-        archive = get_test_data(path)
-        target = archive + extension
+        target = _temporary_directory_for_test_data(path) + extension
 
         if os.path.exists(target):
             return target
 
+        archive = get_test_data(path)
+
         shutil.unpack_archive(archive, os.path.dirname(target) + ".tmp")
         os.rename(os.path.dirname(target) + ".tmp", target)
+
+        os.remove(archive)
 
         return target
 


### PR DESCRIPTION
## Description
Problem: If an archive is downloaded twice in the same pytest run, we unpack the archive and write it to the existing temp directory containing the unpacked archive

Solution: If the dir with the unpacked archive already exists, return the path to the directory directly

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update