### PR TITLE
feat: allow wildcard in config for matching s3 buckets to end points

### DIFF
--- a/src/anemoi/utils/remote/s3.py
+++ b/src/anemoi/utils/remote/s3.py
@@ -690,7 +690,7 @@ def quotas(target: str) -> dict:
     from botocore.exceptions import ClientError
 
     _, _, bucket, _ = target.split("/", 3)
-    s3 = s3_client(bucket, service="service-quotas")  
+    s3 = s3_client(bucket, service="service-quotas")
 
     try:
         return s3.list_service_quotas(ServiceCode="ec2")


### PR DESCRIPTION
## Description

Allow wildcard in config for matching s3 buckets to end points.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
