### PR TITLE
fix: treat mlflow as an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ optional-dependencies.docs = [
 
 optional-dependencies.grib = [ "requests" ]
 
-optional-dependencies.mlflow = [ "mlflow>=2.11.1" ]
+optional-dependencies.mlflow = [ "mlflow>=2.11.1", "requests" ]
 
 optional-dependencies.provenance = [ "gitpython", "nvsmi" ]
 

--- a/src/anemoi/utils/mlflow/client.py
+++ b/src/anemoi/utils/mlflow/client.py
@@ -12,7 +12,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from mlflow import MlflowClient
+try:
+    from mlflow import MlflowClient
+except ImportError:
+    raise ImportError(
+        "The `mlflow` package is required to use AnemoiMLflowclient. Please install it with `pip install mlflow`."
+    )
 
 from .auth import TokenAuth
 from .utils import health_check


### PR DESCRIPTION
## Description
Mlflow is supposed to be optional, while we import it explicitly in the `anemoi.utils.mlflow.client` module. This is not very critical because the mlflow import is contained within the mlflow submodule only. So not having mlflow installed won't impact other users, but nevertheless this small PR wraps the mlflow import in a try block and show a meaningful error if it fails. 

##  Additional notes ##
Additionally, this PR add `requests` to the mlflow extras, as this is imported in the new `mlflow.auth` and  `mlflow.utils` submodules. However, requests is already implicitly a normal dependency, as it is required by `multiurl`.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
