### PR TITLE
feat: Protect mlflow token file

### DIFF
--- a/src/anemoi/utils/mlflow/auth.py
+++ b/src/anemoi/utils/mlflow/auth.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 import requests
 from requests.exceptions import HTTPError
 
+from ..config import config_path
 from ..config import load_config
 from ..config import save_config
 from ..remote import robust
@@ -87,6 +88,14 @@ class TokenAuth:
 
     @staticmethod
     def load_config() -> dict:
+        path = config_path(TokenAuth.config_file)
+
+        if not os.path.exists(path):
+            save_config(TokenAuth.config_file, {})
+
+        if os.stat(path).st_mode & 0o777 != 0o600:
+            os.chmod(path, 0o600)
+
         return load_config(TokenAuth.config_file)
 
     def enabled(fn: Callable) -> Callable:  # noqa: N805

--- a/src/anemoi/utils/mlflow/auth.py
+++ b/src/anemoi/utils/mlflow/auth.py
@@ -93,7 +93,7 @@ class TokenAuth:
         if not os.path.exists(path):
             save_config(TokenAuth.config_file, {})
 
-        if os.stat(path).st_mode & 0o777 != 0o600:
+        if os.path.exists(path) and os.stat(path).st_mode & 0o777 != 0o600:
             os.chmod(path, 0o600)
 
         return load_config(TokenAuth.config_file)


### PR DESCRIPTION
## Description
We did not properly protect the mlflow file. 

This puts a check and chmod in the load function so people's existing token file will be protected next time it's loaded. 


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
