### PR TITLE
feat(deps): Use mlflow-skinny instead of mlflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ optional-dependencies.docs = [
 
 optional-dependencies.grib = [ "requests" ]
 
-optional-dependencies.mlflow = [ "mlflow>=2.11.1", "requests" ]
+optional-dependencies.mlflow = [ "mlflow-skinny>=2.11.1", "requests" ]
 
 optional-dependencies.provenance = [ "gitpython", "nvsmi" ]
 
@@ -77,7 +77,7 @@ optional-dependencies.s3 = [
   "boto3>1.36",
 ]
 
-optional-dependencies.tests = [ "pytest", "pytest-mock>=3" ]
+optional-dependencies.tests = [ "anemoi-utils[mlflow]", "pytest", "pytest-mock>=3" ]
 
 optional-dependencies.text = [ "termcolor", "wcwidth" ]
 


### PR DESCRIPTION
## Description
Regular mlflow pulls in things like scikit-learn, which are not needed here. We only use the MlflowClient, so mlflow-skinny is enough.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
