### PR TITLE
fix: remove too many warnings

### DIFF
--- a/src/anemoi/utils/config.py
+++ b/src/anemoi/utils/config.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import threading
+import warnings
 from typing import Any
 
 import yaml
@@ -202,12 +203,8 @@ class DotDict(dict):
         value = self.convert_to_nested_dot_dict(value)
         super().__setitem__(key, value)
 
-    @staticmethod
-    def warn_on_mutation(key):
-        LOG.warning(
-            f"Config key '{key}' was modified after instantiation. "
-            "This is bad practice — configs are intended to be immutable. "
-        )
+    def warn_on_mutation(self, key):
+        warnings.warn("Mofifying and instance of DotDict(). This class is intended to be immutable.")
 
     def __repr__(self) -> str:
         """Return a string representation of the DotDict.


### PR DESCRIPTION
## Description

Issue only one warning when updating DotDict

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
