### PR TITLE
refactor: remove skip_slow_tests decorator from utils

### DIFF
--- a/src/anemoi/utils/testing.py
+++ b/src/anemoi/utils/testing.py
@@ -240,17 +240,6 @@ def _missing_packages(*names: str) -> list[str]:
     return missing
 
 
-def _run_slow_tests() -> bool:
-    """Check if the SLOW_TESTS environment variable is set.
-
-    Returns
-    -------
-    bool
-        True if the SLOW_TESTS environment variable is set, False otherwise.
-    """
-    return bool(int(os.environ.get("SLOW_TESTS", 0)))
-
-
 @lru_cache(maxsize=None)
 def _offline() -> bool:
     """Check if we are offline."""
@@ -265,7 +254,6 @@ def _offline() -> bool:
 
 
 skip_if_offline = pytest.mark.skipif(_offline(), reason="No internet connection")
-skip_slow_tests = pytest.mark.skipif(not _run_slow_tests(), reason="Skipping slow tests")
 
 
 def skip_missing_packages(*names: str) -> pytest.MarkDecorator:


### PR DESCRIPTION
## Description
Remove the skip_slow_tests decorator as we use pytest markers to mark slow tests in the downstream repos. Requires https://github.com/ecmwf/anemoi-datasets/pull/399 to be merged first

## What problem does this change solve?
Make markers and cli for slow tests consistent across the anemoi packages.

## What issue or task does this change relate to?
https://github.com/ecmwf/anemoi-core/issues/257

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
