### PR TITLE
feat: NoAuth for AML mlflow Logging

### DIFF
--- a/src/anemoi/utils/mlflow/auth.py
+++ b/src/anemoi/utils/mlflow/auth.py
@@ -18,6 +18,7 @@ from datetime import timezone
 from functools import wraps
 from getpass import getpass
 from typing import TYPE_CHECKING
+from abc import ABC, abstractmethod
 
 import requests
 from requests.exceptions import HTTPError
@@ -35,7 +36,43 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-class TokenAuth:
+class AuthBase(ABC):
+    """Base class for authentication implementations."""
+
+    @abstractmethod
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @abstractmethod
+    def save(self, **kwargs):
+        pass
+
+    @abstractmethod
+    def login(self, force_credentials: bool = False, **kwargs):
+        pass
+
+    @abstractmethod
+    def authenticate(self, **kwargs):
+        pass
+
+
+class NoAuth(AuthBase):
+    """No-op authentication class."""
+
+    def __init__(self, *args, **kwargs):
+        self._enabled = False
+
+    def save(self, **kwargs):
+        pass
+
+    def login(self, force_credentials: bool = False, **kwargs):
+        pass
+
+    def authenticate(self, **kwargs):
+        pass
+
+
+class TokenAuth(AuthBase):
     """Manage authentication with a keycloak token server."""
 
     config_file = "mlflow-token.json"
@@ -253,14 +290,3 @@ class TokenAuth:
         except HTTPError:
             self.log.exception("HTTP error occurred")
             raise
-
-
-class PassiveAuth(TokenAuth):
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def authenticate(self):
-        pass
-
-    def save(self):
-        pass

--- a/src/anemoi/utils/mlflow/auth.py
+++ b/src/anemoi/utils/mlflow/auth.py
@@ -253,3 +253,14 @@ class TokenAuth:
         except HTTPError:
             self.log.exception("HTTP error occurred")
             raise
+
+
+class PassiveAuth(TokenAuth):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def authenticate(self):
+        pass
+
+    def save(self):
+        pass

--- a/src/anemoi/utils/mlflow/auth.py
+++ b/src/anemoi/utils/mlflow/auth.py
@@ -13,12 +13,13 @@ from __future__ import annotations
 import logging
 import os
 import time
+from abc import ABC
+from abc import abstractmethod
 from datetime import datetime
 from datetime import timezone
 from functools import wraps
 from getpass import getpass
 from typing import TYPE_CHECKING
-from abc import ABC, abstractmethod
 
 import requests
 from requests.exceptions import HTTPError

--- a/tests/test_mlflow_auth.py
+++ b/tests/test_mlflow_auth.py
@@ -14,7 +14,7 @@ import time
 
 import pytest
 
-from anemoi.utils.mlflow.auth import TokenAuth
+from anemoi.utils.mlflow.auth import NoAuth, TokenAuth
 
 
 def mocks(
@@ -160,3 +160,19 @@ def test_target_env_var(mocker: pytest.MockerFixture) -> None:
     auth.authenticate()
 
     os.environ.__setitem__.assert_called_once_with("MLFLOW_TEST_ENV_VAR", "access_token")
+
+
+def test_noauth_init():
+    """Test NoAuth can be initialized without error."""
+    auth = NoAuth()
+    assert isinstance(auth, NoAuth)
+    assert hasattr(auth, '_enabled')
+    assert auth._enabled is False
+
+
+def test_noauth_methods_do_nothing():
+    """Test NoAuth methods do nothing and return None."""
+    auth = NoAuth()
+    assert auth.save() is None
+    assert auth.login() is None
+    assert auth.authenticate() is None

--- a/tests/test_mlflow_auth.py
+++ b/tests/test_mlflow_auth.py
@@ -14,7 +14,8 @@ import time
 
 import pytest
 
-from anemoi.utils.mlflow.auth import NoAuth, TokenAuth
+from anemoi.utils.mlflow.auth import NoAuth
+from anemoi.utils.mlflow.auth import TokenAuth
 
 
 def mocks(
@@ -166,7 +167,7 @@ def test_noauth_init():
     """Test NoAuth can be initialized without error."""
     auth = NoAuth()
     assert isinstance(auth, NoAuth)
-    assert hasattr(auth, '_enabled')
+    assert hasattr(auth, "_enabled")
     assert auth._enabled is False
 
 


### PR DESCRIPTION
## Description

This is a support PR for ecmwf/anemoi-core#469. My basic understanding is that the authentication processes are applicable to AML mlflow logging, since lots of credentials are required to setup the workspace in the first place. So, this creates a PassiveAuth authenticator to allow the AnemoiAzureMlflowLogger to be a child class of the AnemoiMlflowLogger parent class, just silently ignoring all the TokenAuth steps.

## What problem does this change solve?

New feature: supports AML mlflow logging.

## What issue or task does this change relate to?

None open but happy to open one if necessary.

##  Additional notes ##

See ecmwf/anemoi-core#469 discussion

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
