### PR TITLE
fix: add missing s3 function used by datasets

### DIFF
--- a/src/anemoi/utils/remote/s3.py
+++ b/src/anemoi/utils/remote/s3.py
@@ -63,7 +63,10 @@ class S3Object:
             S3 URL (e.g., 's3://bucket/key').
         """
         self.url = url
-        s3, empty, self.bucket, self.key = url.split("/", 3)
+        try:
+            s3, empty, self.bucket, self.key = url.split("/", 3)
+        except ValueError:
+            raise ValueError(f"Invalid S3 URL: {url}")
         assert s3 == "s3:"
         assert empty == ""
         self.dirname = f"s3://{self.bucket}"
@@ -481,6 +484,25 @@ def object_exists(target: str) -> bool:
         return True
     except FileNotFoundError:
         return False
+
+
+def get_object(target: str) -> bool:
+    """Check if an S3 object exists.
+
+    Parameters
+    ----------
+    target : str
+        S3 object URL.
+
+    Returns
+    -------
+    bool
+        True if object exists, False otherwise.
+    """
+    obj = _s3_object(target)
+    s3 = s3_client(obj)
+
+    return s3.get(obj.key).bytes()
 
 
 def download(source: str, target: str, *args, **kwargs) -> None:


### PR DESCRIPTION
## Description

Add missing`get_object` function used by datasets

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
