### PR TITLE
feat: Speedup checkpoint editing - remove compression

### DIFF
--- a/src/anemoi/utils/checkpoints.py
+++ b/src/anemoi/utils/checkpoints.py
@@ -214,7 +214,7 @@ def save_metadata(
             zipf.writestr(entry["path"], value.tobytes())
 
 
-def _edit_metadata(path: str, name: str, callback: Callable, supporting_arrays: dict = None) -> None:
+def _edit_metadata(path: str, name: str, callback: Callable, supporting_arrays: dict | None = None) -> None:
     """Edit metadata in a checkpoint file.
 
     Parameters
@@ -230,41 +230,56 @@ def _edit_metadata(path: str, name: str, callback: Callable, supporting_arrays: 
     """
     new_path = f"{path}.anemoi-edit-{time.time()}-{os.getpid()}.tmp"
 
-    found = False
+    with zipfile.ZipFile(path, "r") as source_zip:
+        file_list = source_zip.namelist()
 
-    directory = None
-    with TemporaryDirectory() as temp_dir:
-        zipfile.ZipFile(path, "r").extractall(temp_dir)
-        total = 0
-        for root, dirs, files in os.walk(temp_dir):
-            for f in files:
-                total += 1
-                full = os.path.join(root, f)
-                if f == name:
-                    found = True
-                    callback(full)
-                    directory = os.path.dirname(full)
+        # Find the target file and its directory
+        target_file = None
+        directory = None
+        for file_path in file_list:
+            if os.path.basename(file_path) == name:
+                target_file = file_path
+                directory = os.path.dirname(file_path)
+                break
 
-        if not found:
+        if target_file is None:
             raise ValueError(f"Could not find '{name}' in {path}")
 
+        # Calculate total files for progress bar
+        total_files = len(file_list)
         if supporting_arrays is not None:
+            total_files += len(supporting_arrays)
 
-            for key, entry in supporting_arrays.items():
-                value = entry.tobytes()
-                fname = os.path.join(directory, f"{key}.numpy")
-                os.makedirs(os.path.dirname(fname), exist_ok=True)
-                with open(fname, "wb") as f:
-                    f.write(value)
-                    total += 1
+        with zipfile.ZipFile(new_path, "w", zipfile.ZIP_STORED) as new_zip:
+            with tqdm.tqdm(total=total_files, desc="Rebuilding checkpoint") as pbar:
 
-        with zipfile.ZipFile(new_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-            with tqdm.tqdm(total=total, desc="Rebuilding checkpoint") as pbar:
-                for root, dirs, files in os.walk(temp_dir):
-                    for f in files:
-                        full = os.path.join(root, f)
-                        rel = os.path.relpath(full, temp_dir)
-                        zipf.write(full, rel)
+                # Copy all files except the target file
+                for file_path in file_list:
+                    if file_path != target_file:
+                        with source_zip.open(file_path) as source_file:
+                            data = source_file.read()
+                            new_zip.writestr(file_path, data)
+                        pbar.update(1)
+
+                # Handle the target file with callback
+                with TemporaryDirectory() as temp_dir:
+                    # Extract only the target file
+                    source_zip.extract(target_file, temp_dir)
+                    target_full_path = os.path.join(temp_dir, target_file)
+
+                    # Apply the callback
+                    callback(target_full_path)
+
+                    # Add the modified file to the new zip (if it still exists)
+                    if os.path.exists(target_full_path):
+                        new_zip.write(target_full_path, target_file)
+                    pbar.update(1)
+
+                # Add supporting arrays if provided
+                if supporting_arrays is not None:
+                    for key, entry in supporting_arrays.items():
+                        array_path = os.path.join(directory, f"{key}.numpy") if directory else f"{key}.numpy"
+                        new_zip.writestr(array_path, entry.tobytes())
                         pbar.update(1)
 
     os.rename(new_path, path)

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -1,0 +1,220 @@
+import json
+import os
+import tempfile
+import zipfile
+
+import numpy as np
+import pytest
+
+from anemoi.utils.checkpoints import _edit_metadata
+from anemoi.utils.checkpoints import has_metadata
+from anemoi.utils.checkpoints import load_metadata
+from anemoi.utils.checkpoints import remove_metadata
+from anemoi.utils.checkpoints import replace_metadata
+from anemoi.utils.checkpoints import save_metadata
+
+
+@pytest.fixture
+def sample_checkpoint():
+    """Create a sample PyTorch checkpoint file for testing."""
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as tmp:
+        checkpoint_path = tmp.name
+
+    # Create a mock PyTorch checkpoint structure
+    with zipfile.ZipFile(checkpoint_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+        # Add some dummy model files
+        zipf.writestr("model/data.pkl", b"fake pytorch data")
+        zipf.writestr("model/tensors.pt", b"fake tensor data")
+        zipf.writestr("model/version", b"3")
+
+        # Add initial metadata
+        metadata = {"version": "1.0", "model_info": {"layers": 10, "parameters": 1000000}}
+        zipf.writestr("model/anemoi-metadata/ai-models.json", json.dumps(metadata))
+
+    yield checkpoint_path
+
+    # Cleanup
+    if os.path.exists(checkpoint_path):
+        os.unlink(checkpoint_path)
+
+
+@pytest.fixture
+def sample_checkpoint_with_arrays():
+    """Create a checkpoint with supporting arrays."""
+    with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as tmp:
+        checkpoint_path = tmp.name
+
+    with zipfile.ZipFile(checkpoint_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+        zipf.writestr("model/data.pkl", b"fake pytorch data")
+        zipf.writestr("model/tensors.pt", b"fake tensor data")
+        zipf.writestr("model/version", b"3")
+
+        # Add metadata with supporting arrays
+        metadata = {
+            "version": "1.0",
+            "supporting_arrays_paths": {
+                "means": {"path": "model/anemoi-metadata/means.numpy", "shape": [10], "dtype": "float64"},
+                "stds": {"path": "model/anemoi-metadata/stds.numpy", "shape": [10], "dtype": "float64"},
+            },
+        }
+        zipf.writestr("model/anemoi-metadata/ai-models.json", json.dumps(metadata))
+
+        # Add supporting arrays
+        means_array = np.random.random(10).astype(np.float64)
+        stds_array = np.random.random(10).astype(np.float64)
+        zipf.writestr("model/anemoi-metadata/means.numpy", means_array.tobytes())
+        zipf.writestr("model/anemoi-metadata/stds.numpy", stds_array.tobytes())
+
+    yield checkpoint_path, means_array, stds_array
+
+    if os.path.exists(checkpoint_path):
+        os.unlink(checkpoint_path)
+
+
+class TestEditMetadata:
+    """Test cases for _edit_metadata function."""
+
+    def test_edit_metadata_basic_functionality(self, sample_checkpoint):
+        """Test basic functionality of _edit_metadata."""
+        original_metadata = load_metadata(sample_checkpoint)
+
+        def update_callback(file_path):
+            with open(file_path, "r") as f:
+                data = json.load(f)
+            data["test_field"] = "test_value"
+            data["version"] = "2.0"
+            with open(file_path, "w") as f:
+                json.dump(data, f)
+
+        _edit_metadata(sample_checkpoint, "ai-models.json", update_callback)
+
+        # Verify the metadata was updated
+        updated_metadata = load_metadata(sample_checkpoint)
+        assert updated_metadata["test_field"] == "test_value"
+        assert updated_metadata["version"] == "2.0"
+        assert updated_metadata["model_info"] == original_metadata["model_info"]
+
+    def test_edit_metadata_with_supporting_arrays(self, sample_checkpoint):
+        """Test _edit_metadata with supporting arrays."""
+        new_means = np.array([1.0, 2.0, 3.0])
+        new_stds = np.array([0.1, 0.2, 0.3])
+        supporting_arrays = {"means": new_means, "stds": new_stds}
+
+        def update_callback(file_path):
+            with open(file_path, "r") as f:
+                data = json.load(f)
+            data["has_arrays"] = True
+            with open(file_path, "w") as f:
+                json.dump(data, f)
+
+        _edit_metadata(sample_checkpoint, "ai-models.json", update_callback, supporting_arrays)
+
+        # Verify arrays were added
+        with zipfile.ZipFile(sample_checkpoint, "r") as zipf:
+            assert "model/anemoi-metadata/means.numpy" in zipf.namelist()
+            assert "model/anemoi-metadata/stds.numpy" in zipf.namelist()
+
+            # Verify array contents
+            means_data = np.frombuffer(zipf.read("model/anemoi-metadata/means.numpy"), dtype=new_means.dtype)
+            stds_data = np.frombuffer(zipf.read("model/anemoi-metadata/stds.numpy"), dtype=new_stds.dtype)
+
+            np.testing.assert_array_equal(means_data, new_means)
+            np.testing.assert_array_equal(stds_data, new_stds)
+
+    def test_edit_metadata_preserves_other_files(self, sample_checkpoint):
+        """Test that _edit_metadata preserves all other files in the ZIP."""
+        with zipfile.ZipFile(sample_checkpoint, "r") as zipf:
+            original_files = set(zipf.namelist())
+
+        def dummy_callback(file_path):
+            pass
+
+        _edit_metadata(sample_checkpoint, "ai-models.json", dummy_callback)
+
+        with zipfile.ZipFile(sample_checkpoint, "r") as zipf:
+            updated_files = set(zipf.namelist())
+
+        # All original files should still be present
+        assert original_files == updated_files
+
+        # Verify non-metadata files are unchanged
+        with zipfile.ZipFile(sample_checkpoint, "r") as zipf:
+            assert zipf.read("model/data.pkl") == b"fake pytorch data"
+            assert zipf.read("model/tensors.pt") == b"fake tensor data"
+            assert zipf.read("model/version") == b"3"
+
+    def test_edit_metadata_file_not_found(self, sample_checkpoint):
+        """Test _edit_metadata raises error when target file not found."""
+
+        def dummy_callback(file_path):
+            pass
+
+        with pytest.raises(ValueError, match="Could not find 'nonexistent.json'"):
+            _edit_metadata(sample_checkpoint, "nonexistent.json", dummy_callback)
+
+    def test_edit_metadata_callback_exception_handling(self, sample_checkpoint):
+        """Test that callback exceptions are properly propagated."""
+
+        def failing_callback(file_path):
+            raise RuntimeError("Callback failed")
+
+        with pytest.raises(RuntimeError, match="Callback failed"):
+            _edit_metadata(sample_checkpoint, "ai-models.json", failing_callback)
+
+        # Original file should be unchanged
+        original_metadata = {"version": "1.0", "model_info": {"layers": 10, "parameters": 1000000}}
+        current_metadata = load_metadata(sample_checkpoint)
+        assert current_metadata == original_metadata
+
+
+class TestEditMetadataIntegration:
+    """Integration tests with other checkpoint functions."""
+
+    def test_replace_metadata_integration(self, sample_checkpoint):
+        """Test that replace_metadata still works after optimization."""
+        new_metadata = {"version": "2.0", "new_field": "new_value", "model_info": {"layers": 20, "parameters": 2000000}}
+
+        replace_metadata(sample_checkpoint, new_metadata)
+
+        loaded_metadata = load_metadata(sample_checkpoint)
+        assert loaded_metadata == new_metadata
+
+    def test_remove_metadata_integration(self, sample_checkpoint):
+        """Test that remove_metadata still works after optimization."""
+        assert has_metadata(sample_checkpoint)
+
+        remove_metadata(sample_checkpoint)
+
+        assert not has_metadata(sample_checkpoint)
+
+    def test_metadata_with_arrays_roundtrip(self, sample_checkpoint):
+        """Test complete roundtrip with supporting arrays."""
+        # First remove existing metadata
+        remove_metadata(sample_checkpoint)
+
+        # Add metadata with arrays
+        metadata = {"version": "1.0", "test": True}
+        arrays = {"test_array": np.array([1, 2, 3, 4, 5])}
+
+        save_metadata(sample_checkpoint, metadata, supporting_arrays=arrays)
+
+        # Load and verify
+        loaded_metadata, loaded_arrays = load_metadata(sample_checkpoint, supporting_arrays=True)
+        assert loaded_metadata["test"] is True
+        np.testing.assert_array_equal(loaded_arrays["test_array"], arrays["test_array"])
+
+        # Edit with _edit_metadata
+        def update_callback(file_path):
+            with open(file_path, "r") as f:
+                data = json.load(f)
+            data["edited"] = True
+            with open(file_path, "w") as f:
+                json.dump(data, f)
+
+        _edit_metadata(sample_checkpoint, "ai-models.json", update_callback)
+
+        # Verify edit preserved arrays
+        final_metadata, final_arrays = load_metadata(sample_checkpoint, supporting_arrays=True)
+        assert final_metadata["edited"] is True
+        assert final_metadata["test"] is True
+        np.testing.assert_array_equal(final_arrays["test_array"], arrays["test_array"])

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -29,7 +29,7 @@ def sample_checkpoint():
 
         # Add initial metadata
         metadata = {"version": "1.0", "model_info": {"layers": 10, "parameters": 1000000}}
-        zipf.writestr("model/anemoi-metadata/ai-models.json", json.dumps(metadata))
+        zipf.writestr("model/anemoi-metadata/metadata.json", json.dumps(metadata))
 
     yield checkpoint_path
 
@@ -57,7 +57,7 @@ def sample_checkpoint_with_arrays():
                 "stds": {"path": "model/anemoi-metadata/stds.numpy", "shape": [10], "dtype": "float64"},
             },
         }
-        zipf.writestr("model/anemoi-metadata/ai-models.json", json.dumps(metadata))
+        zipf.writestr("model/anemoi-metadata/metadata.json", json.dumps(metadata))
 
         # Add supporting arrays
         means_array = np.random.random(10).astype(np.float64)
@@ -76,7 +76,7 @@ class TestEditMetadata:
 
     def test_edit_metadata_basic_functionality(self, sample_checkpoint):
         """Test basic functionality of _edit_metadata."""
-        original_metadata = load_metadata(sample_checkpoint)
+        original_metadata = load_metadata(sample_checkpoint, name="metadata.json")
 
         def update_callback(file_path):
             with open(file_path, "r") as f:
@@ -86,10 +86,10 @@ class TestEditMetadata:
             with open(file_path, "w") as f:
                 json.dump(data, f)
 
-        _edit_metadata(sample_checkpoint, "ai-models.json", update_callback)
+        _edit_metadata(sample_checkpoint, "metadata.json", update_callback)
 
         # Verify the metadata was updated
-        updated_metadata = load_metadata(sample_checkpoint)
+        updated_metadata = load_metadata(sample_checkpoint, name="metadata.json")
         assert updated_metadata["test_field"] == "test_value"
         assert updated_metadata["version"] == "2.0"
         assert updated_metadata["model_info"] == original_metadata["model_info"]
@@ -107,7 +107,7 @@ class TestEditMetadata:
             with open(file_path, "w") as f:
                 json.dump(data, f)
 
-        _edit_metadata(sample_checkpoint, "ai-models.json", update_callback, supporting_arrays)
+        _edit_metadata(sample_checkpoint, "metadata.json", update_callback, supporting_arrays)
 
         # Verify arrays were added
         with zipfile.ZipFile(sample_checkpoint, "r") as zipf:
@@ -129,7 +129,7 @@ class TestEditMetadata:
         def dummy_callback(file_path):
             pass
 
-        _edit_metadata(sample_checkpoint, "ai-models.json", dummy_callback)
+        _edit_metadata(sample_checkpoint, "metadata.json", dummy_callback)
 
         with zipfile.ZipFile(sample_checkpoint, "r") as zipf:
             updated_files = set(zipf.namelist())
@@ -159,11 +159,11 @@ class TestEditMetadata:
             raise RuntimeError("Callback failed")
 
         with pytest.raises(RuntimeError, match="Callback failed"):
-            _edit_metadata(sample_checkpoint, "ai-models.json", failing_callback)
+            _edit_metadata(sample_checkpoint, "metadata.json", failing_callback)
 
         # Original file should be unchanged
         original_metadata = {"version": "1.0", "model_info": {"layers": 10, "parameters": 1000000}}
-        current_metadata = load_metadata(sample_checkpoint)
+        current_metadata = load_metadata(sample_checkpoint, name="metadata.json")
         assert current_metadata == original_metadata
 
 
@@ -174,32 +174,32 @@ class TestEditMetadataIntegration:
         """Test that replace_metadata still works after optimization."""
         new_metadata = {"version": "2.0", "new_field": "new_value", "model_info": {"layers": 20, "parameters": 2000000}}
 
-        replace_metadata(sample_checkpoint, new_metadata)
+        replace_metadata(sample_checkpoint, new_metadata, name="metadata.json")
 
-        loaded_metadata = load_metadata(sample_checkpoint)
+        loaded_metadata = load_metadata(sample_checkpoint, name="metadata.json")
         assert loaded_metadata == new_metadata
 
     def test_remove_metadata_integration(self, sample_checkpoint):
         """Test that remove_metadata still works after optimization."""
-        assert has_metadata(sample_checkpoint)
+        assert has_metadata(sample_checkpoint, name="metadata.json")
 
-        remove_metadata(sample_checkpoint)
+        remove_metadata(sample_checkpoint, name="metadata.json")
 
-        assert not has_metadata(sample_checkpoint)
+        assert not has_metadata(sample_checkpoint, name="metadata.json")
 
     def test_metadata_with_arrays_roundtrip(self, sample_checkpoint):
         """Test complete roundtrip with supporting arrays."""
         # First remove existing metadata
-        remove_metadata(sample_checkpoint)
+        remove_metadata(sample_checkpoint, name="metadata.json")
 
         # Add metadata with arrays
         metadata = {"version": "1.0", "test": True}
         arrays = {"test_array": np.array([1, 2, 3, 4, 5])}
 
-        save_metadata(sample_checkpoint, metadata, supporting_arrays=arrays)
+        save_metadata(sample_checkpoint, metadata, supporting_arrays=arrays, name="metadata.json")
 
         # Load and verify
-        loaded_metadata, loaded_arrays = load_metadata(sample_checkpoint, supporting_arrays=True)
+        loaded_metadata, loaded_arrays = load_metadata(sample_checkpoint, supporting_arrays=True, name="metadata.json")
         assert loaded_metadata["test"] is True
         np.testing.assert_array_equal(loaded_arrays["test_array"], arrays["test_array"])
 
@@ -211,10 +211,10 @@ class TestEditMetadataIntegration:
             with open(file_path, "w") as f:
                 json.dump(data, f)
 
-        _edit_metadata(sample_checkpoint, "ai-models.json", update_callback)
+        _edit_metadata(sample_checkpoint, "metadata.json", update_callback)
 
         # Verify edit preserved arrays
-        final_metadata, final_arrays = load_metadata(sample_checkpoint, supporting_arrays=True)
+        final_metadata, final_arrays = load_metadata(sample_checkpoint, supporting_arrays=True, name="metadata.json")
         assert final_metadata["edited"] is True
         assert final_metadata["test"] is True
         np.testing.assert_array_equal(final_arrays["test_array"], arrays["test_array"])


### PR DESCRIPTION
## Description
Checkpoint rebuilding can be quite slow for large models, as `ZIP_DEFLATED` was being used
Switching to `ZIP_STORED` for no compression results in a large speed up, and since torch checkpoints contain already-compressed tensor data, `ZIP_STORED` gives speed gains with minimal size penalty.

```
=== BENCHMARK RESULTS ===
Edit time: 3.52 seconds
Original size: 1262.4 MB
Output file size: 1262.4 MB
Throughput: 358.9 MB/s
```
Used to take 117 secs, now 3.52, so 33x

- Also adds tests for the checkpoint code to ensure compatability
- Reworked the code for clarity

> [!NOTE]
> New checkpoints have been run with inference and appear fine


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
