### PR TITLE
feat: add aliases to registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dynamic = [ "version" ]
 dependencies = [
   "aniso8601",
   "deprecation",
+  "entrypoints",
   "importlib-metadata; python_version<'3.10'",
   "multiurl",
   "numpy",

--- a/src/anemoi/utils/registry.py
+++ b/src/anemoi/utils/registry.py
@@ -97,6 +97,8 @@ class Registry(Generic[T]):
         self.package = package
         self.__registered = {}
         self._sources = {}
+        self._aliases = {}
+        self._warnings = set()
         self.kind = package.split(".")[-1]
         self.key = key
         self.api_version = api_version
@@ -118,7 +120,9 @@ class Registry(Generic[T]):
         """
         return _BY_KIND.get(kind)
 
-    def register(self, name: str, factory: Callable | None = None, source: Any | None = None) -> Wrapper | None:
+    def register(
+        self, name: str, factory: Callable | None = None, source: Any | None = None, aliases: list[str] | None = None
+    ) -> Wrapper | None:
         """Register a factory with the registry.
 
         Parameters
@@ -129,6 +133,8 @@ class Registry(Generic[T]):
             The factory to register, by default None.
         source : Any, optional
             The source of the factory, by default None.
+        aliases : list of str, optional
+            Aliases for the factory, by default None.
 
         Returns
         -------
@@ -136,7 +142,13 @@ class Registry(Generic[T]):
             A wrapper if the factory is None, otherwise None.
         """
 
+        aliases = aliases or []
+
         name = name.replace("_", "-")
+        assert (
+            name not in self._aliases
+        ), f"'{name}' is already registered for '{self._aliases[name]}' in {self.package}"
+        assert name not in aliases, f"'{name}' cannot be an alias for itself in {self.package}"
 
         if factory is None:
             # This happens when the @register decorator is used
@@ -149,6 +161,15 @@ class Registry(Generic[T]):
             warnings.warn(f"Factory '{name}' is already registered in {self.package}")
             warnings.warn(f"Existing: {self._sources[name]}")
             warnings.warn(f"New: {source}")
+
+        for alias in aliases:
+            assert (
+                alias not in self.__registered
+            ), f"Alias '{alias}' is already registered as a factory in {self.package}"
+            alias = alias.replace("_", "-")
+            if alias in self._aliases:
+                warnings.warn(f"Alias '{alias}' is already registered for '{self._aliases[alias]}' in {self.package}")
+            self._aliases[alias] = name
 
         self.__registered[name] = factory
         self._sources[name] = source
@@ -188,6 +209,7 @@ class Registry(Generic[T]):
         """
 
         name = name.replace("_", "-")
+        name = self.unalias(name)
 
         ok = name in self.factories
         if not ok:
@@ -213,6 +235,7 @@ class Registry(Generic[T]):
         """
 
         name = name.replace("_", "-")
+        name = self.unalias(name)
 
         if return_none:
             return self.factories.get(name)
@@ -305,6 +328,7 @@ class Registry(Generic[T]):
         """
 
         name = name.replace("_", "-")
+        name = self.unalias(name)
 
         factory = self.lookup(name)
         return factory(*args, **kwargs)
@@ -352,3 +376,26 @@ class Registry(Generic[T]):
         raise ValueError(
             f"Entry '{config}' must either be a string, a dictionary with a single entry, or a dictionary with a '{self.key}' key"
         )
+
+    def unalias(self, name: str) -> str:
+        """Resolve an alias to its canonical name.
+
+        Parameters
+        ----------
+        name : str
+            The name to resolve.
+
+        Returns
+        -------
+        str
+            The canonical name.
+        """
+        canonical = self._aliases.get(name, name)
+        if canonical != name:
+            warnings.warn(
+                f"Alias '{name}' for '{canonical}' in {self.package} is deprecated and will be removed in a future version.",
+                category=DeprecationWarning,
+                # stacklevel=2,
+            )
+
+        return canonical

--- a/src/anemoi/utils/registry.py
+++ b/src/anemoi/utils/registry.py
@@ -209,7 +209,7 @@ class Registry(Generic[T]):
         """
 
         name = name.replace("_", "-")
-        name = self.unalias(name)
+        name = self._unalias(name)
 
         ok = name in self.factories
         if not ok:
@@ -235,7 +235,7 @@ class Registry(Generic[T]):
         """
 
         name = name.replace("_", "-")
-        name = self.unalias(name)
+        name = self._unalias(name)
 
         if return_none:
             return self.factories.get(name)
@@ -328,7 +328,7 @@ class Registry(Generic[T]):
         """
 
         name = name.replace("_", "-")
-        name = self.unalias(name)
+        name = self._unalias(name)
 
         factory = self.lookup(name)
         return factory(*args, **kwargs)
@@ -377,7 +377,7 @@ class Registry(Generic[T]):
             f"Entry '{config}' must either be a string, a dictionary with a single entry, or a dictionary with a '{self.key}' key"
         )
 
-    def unalias(self, name: str) -> str:
+    def _unalias(self, name: str) -> str:
         """Resolve an alias to its canonical name.
 
         Parameters
@@ -399,3 +399,10 @@ class Registry(Generic[T]):
             )
 
         return canonical
+
+    def aliases(self):
+        """Get the aliases."""
+        result = {}
+        for alias, name in self._aliases.items():
+            result.setdefault(name, []).append(alias)
+        return result

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,64 @@
+# (C) Copyright 2025 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import pytest
+
+
+def test_registry() -> None:
+    """Test the Registry class for registering and retrieving factories.
+
+    Tests:
+        - Registering factories with and without aliases.
+        - Retrieving factories by name and alias.
+        - Handling of non-existent factories.
+        - Ensuring that warnings are issued for duplicate registrations.
+    """
+    from anemoi.utils.registry import Registry
+
+    reg = Registry("anemoi.utils", key="name")
+
+    def factory_a():
+        return "Factory A"
+
+    def factory_b():
+        return "Factory B"
+
+    # Register factories
+    reg.register("factory-a", factory_a, source="test_registry", aliases=["fa", "alpha"])
+    reg.register("factory-b", factory_b, source="test_registry")
+
+    # Retrieve factories by name
+    assert reg.lookup("factory-a") == factory_a
+    assert reg.lookup("factory-b") == factory_b
+
+    # Retrieve factories by alias
+    assert reg.lookup("fa") == factory_a
+    assert reg.lookup("alpha") == factory_a
+
+    # Attempt to retrieve a non-existent factory
+    assert reg.lookup("non-existent", return_none=True) is None
+
+    # Call factories
+    assert reg.lookup("factory-a")() == "Factory A"
+    assert reg.lookup("fa")() == "Factory A"
+    assert reg.lookup("factory-b")() == "Factory B"
+
+    # Test duplicate registration warning (this will not raise an error, just a warning)
+
+    with pytest.warns(UserWarning, match="is already registered"):
+        reg.register("factory-a", factory_a, source="test_registry_duplicate")
+
+    # Check that using an alias triggers a deprecation warning
+
+    with pytest.warns(DeprecationWarning, match="Alias 'fa' for 'factory-a' in anemoi.utils is deprecated"):
+        reg.lookup("fa")
+
+
+if __name__ == "__main__":
+    test_registry()


### PR DESCRIPTION
## Description

Add aliases to the registry. The same filter, input, etc can be registered with a canonical name and some aliases.

## What problem does this change solve?

This will allow migration of filter names to something more consistent while keeping backwards compatibility.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
