### PR TITLE
fix: Update s3 chunk size to 10 MB

### DIFF
--- a/src/anemoi/utils/remote/s3.py
+++ b/src/anemoi/utils/remote/s3.py
@@ -262,7 +262,7 @@ def upload_file(source: str, target: str, overwrite: bool, resume: bool, verbosi
         leave=verbosity >= 2,
         delay=0 if verbosity > 0 else 10,
     ) as pbar:
-        chunk_size = 1024 * 1024
+        chunk_size = 1024 * 1024 * 10
         total = size
         with open(source, "rb") as f:
             with closing(obstore.open_writer(s3, obj.key, buffer_size=chunk_size)) as g:
@@ -331,7 +331,7 @@ def download_file(source: str, target: str, overwrite: bool, resume: bool, verbo
         leave=verbosity >= 2,
         delay=0 if verbosity > 0 else 10,
     ) as pbar:
-        chunk_size = 1024 * 1024
+        chunk_size = 1024 * 1024 * 10
         total = size
         with closing(obstore.open_reader(s3, obj.key, buffer_size=chunk_size)) as f:
             with open(target, "wb") as g:


### PR DESCRIPTION
## Description

Increases the s3 chunk size from 1 MB to 10 MB.

## What problem does this change solve?

Issues when writing objects to store.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
