### PR TITLE
fix: Reraise exceptions in CLI-mode if run in debugger

### DIFF
--- a/src/anemoi/utils/cli.py
+++ b/src/anemoi/utils/cli.py
@@ -265,8 +265,11 @@ def cli_main(
         else:
             cmd.run(args)
     except ValueError as e:
-
         if test_arguments:
+            raise
+
+        if sys.excepthook is not sys.__excepthook__:
+            # re-raise exception if non-default excepthook is set (e.g. in pdb)
             raise
 
         traceback.print_exc()


### PR DESCRIPTION
## Description
Many exceptions raised by `anemoi-datasets` are of type `ValueError`. Thus they are caught by `cli_main` and converted to a more user-friendly error. While this might increase the user experience, it prevents the use of Python debuggers.

## What problem does this change solve?
Enable the use of debuggers to debug cli runs.

E.g. `ipdb3 $(which anemoi-datasets) create ...`

## What issue or task does this change relate to?

##  Additional notes ##

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
