### PR TITLE
test: Sane test data download retries

### DIFF
--- a/src/anemoi/utils/testing.py
+++ b/src/anemoi/utils/testing.py
@@ -114,7 +114,7 @@ class GetTestData:
 
         LOG.info(f"Downloading test data from {url} to {target}")
 
-        download(url, target, maximum_retries=10, retry_after=60)
+        download(url, target, maximum_retries=5, retry_after=60)
 
         if gzipped:
             import gzip


### PR DESCRIPTION
### Description
The default number of retries of `multiurl.download` are very high:

https://github.com/ecmwf/multiurl/blob/develop/multiurl/http.py#L54-L55

In case of network errors, it will retry for 16 hours. Lower this to a saner value. I believe this is one of the reasons the CI is sometimes hanging for a long time.

I chose arbitrary new values, input welcome. 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
BEGIN_COMMIT_OVERRIDE
feat(testing): Sane test data download retries (#227)
END_COMMIT_OVERRIDE