### PR TITLE
fix: support dicts of supporting_arrays

### DIFF
--- a/src/anemoi/utils/checkpoints.py
+++ b/src/anemoi/utils/checkpoints.py
@@ -15,12 +15,12 @@ are zip archives containing the model weights.
 import json
 import logging
 import os
-import numpy as np
 import time
 import zipfile
 from collections.abc import Callable
 from tempfile import TemporaryDirectory
 
+import numpy as np
 import tqdm
 
 LOG = logging.getLogger(__name__)
@@ -158,7 +158,7 @@ def _get_supporting_arrays_paths(directory: str, folder: str, supporting_arrays:
             new_key: _get_supporting_arrays_paths(f"{directory}/{folder}", new_key, new_value)
             for new_key, new_value in supporting_arrays.items()
         }
-    
+
     return dict(
         path=f"{directory}/{folder}.numpy",
         shape=supporting_arrays.shape,
@@ -172,7 +172,7 @@ def _write_array_to_bytes(array: dict | np.ndarray, name: str, entry: dict, zipf
         for sub_name, sub_array in array.items():
             _write_array_to_bytes(sub_array, sub_name, entry[sub_name], zipf)
         return None
-    
+
     LOG.info(
         "Saving supporting array `%s` to %s (shape=%s, dtype=%s)",
         name,


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->
This is need to support passing `dict[str, dict[str, np.ndarray]]` as supporting arrays to the `save_metadata()` funcition.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
