### PR TITLE
feat(testing): Add download timeout

### DIFF
--- a/src/anemoi/utils/testing.py
+++ b/src/anemoi/utils/testing.py
@@ -114,7 +114,7 @@ class GetTestData:
 
         LOG.info(f"Downloading test data from {url} to {target}")
 
-        download(url, target, maximum_retries=5, retry_after=60, timeout=10)
+        download(url, target, maximum_retries=5, retry_after=60, timeout=60)
 
         if gzipped:
             import gzip


### PR DESCRIPTION
## Description
Follow up of #227 : also add a timeout to the download function. By default there is no timeout on `requests.get` (which is used under the hood), so downloads could hang indefinitely if the server times out and doesn't close the connection.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
