### PR TITLE
fix: missing bool check of resume in download

### DIFF
--- a/src/anemoi/utils/remote/s3.py
+++ b/src/anemoi/utils/remote/s3.py
@@ -340,7 +340,7 @@ def download_file(source: str, target: str, overwrite: bool, resume: bool, verbo
             else:
                 return size
 
-    if os.path.exists(target) and not overwrite:
+    if os.path.exists(target) and not overwrite and not resume:
         raise ValueError(f"{target} already exists, use 'overwrite' to replace or 'resume' to skip")
 
     with tqdm.tqdm(


### PR DESCRIPTION
## Description
When an incomplete file was encountered in the s3 download, even with resume it would fail.
It was missing a bool check.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
