### PR TITLE
fix: don't skip tests marked as @skip_if_offline when running CIs

### DIFF
--- a/src/anemoi/utils/testing.py
+++ b/src/anemoi/utils/testing.py
@@ -246,8 +246,16 @@ def _offline() -> bool:
     from urllib import request
     from urllib.error import URLError
 
+    # We consider ourselves online in CI environments, so that tests can run there
+    # even if the website is not reachable. This ensure that we don't skip tests
+    # unexpectedly in CI.
+
+    IN_CI = (os.environ.get("GITHUB_WORKFLOW") is not None) or (os.environ.get("IN_CI_HPC") is not None)
+    if IN_CI:
+        return False
+
     try:
-        request.urlopen("https://anemoi.ecmwf.int", timeout=1)
+        request.urlopen("https://anemoi.ecmwf.int/status", timeout=10)
         return False
     except URLError:
         return True


### PR DESCRIPTION
## Description

Don't skip tests marked as @skip_if_offline when running CIs. This can happen if we cannot reach `anemoi.ecmwf.int` for some reason (or we timeout). We know that CIs have access to the internet. Also, added a longer timeout, and use a URL that is directly served my nginx and not the catalogue itself.


## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
