### PR TITLE
fix: Add Filelock to cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "aniso8601",
   "deprecation",
   "entrypoints",
+  "filelock",
   "importlib-metadata; python_version<'3.10'",
   "multiurl",
   "numpy",

--- a/src/anemoi/utils/caching.py
+++ b/src/anemoi/utils/caching.py
@@ -128,9 +128,6 @@ class Cacher:
 
         lock_file = os.path.join(path, f"{m}.lock")
         with FileLock(lock_file):
-            if m in CACHE:
-                return CACHE[m]
-
             filename = os.path.join(path, m) + self.ext
             if os.path.exists(filename):
                 data = self.load(filename)

--- a/src/anemoi/utils/caching.py
+++ b/src/anemoi/utils/caching.py
@@ -17,6 +17,7 @@ from threading import Lock
 from typing import Any
 
 import numpy as np
+from filelock import FileLock
 
 LOCK = Lock()
 CACHE = {}
@@ -40,6 +41,8 @@ def _get_cache_path(collection: str) -> str:
 
 def clean_cache(collection: str = "default") -> None:
     """Clean the cache for a collection.
+
+    This removes all cached data files and their associated lock files.
 
     Parameters
     ----------
@@ -121,25 +124,30 @@ class Cacher:
             return CACHE[m]
 
         path = _get_cache_path(self.collection)
-
-        filename = os.path.join(path, m) + self.ext
-        if os.path.exists(filename):
-            data = self.load(filename)
-            if self.expires is None or data["expires"] > time.time():
-                if data["key"] == key:
-                    return data["value"]
-
-        value = proc()
-        data = {"key": key, "value": value}
-        if self.expires is not None:
-            data["expires"] = time.time() + self.expires
-
         os.makedirs(path, exist_ok=True)
-        temp_filename = self.save(filename, data)
-        os.rename(temp_filename, filename)
 
-        CACHE[m] = value
-        return value
+        lock_file = os.path.join(path, f"{m}.lock")
+        with FileLock(lock_file):
+            if m in CACHE:
+                return CACHE[m]
+
+            filename = os.path.join(path, m) + self.ext
+            if os.path.exists(filename):
+                data = self.load(filename)
+                if self.expires is None or data["expires"] > time.time():
+                    if data["key"] == key:
+                        return data["value"]
+
+            value = proc()
+            data = {"key": key, "value": value}
+            if self.expires is not None:
+                data["expires"] = time.time() + self.expires
+
+            temp_filename = self.save(filename, data)
+            os.rename(temp_filename, filename)
+
+            CACHE[m] = value
+            return value
 
 
 class JsonCacher(Cacher):


### PR DESCRIPTION
## Description
Issues were caused when running tests in parallel as a rename was triggered on a missing file.
As can be seen [here](https://github.com/ecmwf/anemoi-plugins-ecmwf/actions/runs/21211982935/job/61022658486?pr=69)
This adds a filelock to the cache to prevent that

Closes https://github.com/ecmwf/anemoi-plugins-ecmwf/issues/67

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
