### PR TITLE
feat(mlflow auth): Add method to get user info from access token

### DIFF
--- a/src/anemoi/utils/mlflow/auth.py
+++ b/src/anemoi/utils/mlflow/auth.py
@@ -10,6 +10,8 @@
 
 from __future__ import annotations
 
+import base64
+import json
 import logging
 import os
 import time
@@ -24,6 +26,7 @@ from typing import TYPE_CHECKING
 
 import requests
 from pydantic import BaseModel
+from pydantic import Field
 from pydantic import RootModel
 from pydantic import field_validator
 from pydantic import model_validator
@@ -41,6 +44,27 @@ REFRESH_EXPIRE_DAYS = 29
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+
+class UserInfo(BaseModel):
+    """User info associated with a token."""
+
+    name: str | None = None
+    email: str | None = None
+    username: str | None = Field(default=None, validation_alias="preferred_username")
+
+    @classmethod
+    def from_jwt(cls, token: str) -> "UserInfo":
+        """Create a UserInfo object from a JWT. The token payload must contain the user info fields."""
+        payload = token.split(".")[1]
+        padded = payload + "=" * (-len(payload) % 4)
+        decoded = base64.b64decode(padded).decode("utf-8")
+        data = json.loads(decoded)
+        return cls(**data)
+
+    def __bool__(self) -> bool:
+        """A UserInfo object evaluates to True if at least one of its fields is not None."""
+        return any(getattr(self, field) is not None for field in UserInfo.model_fields)
 
 
 class ServerConfig(BaseModel):
@@ -112,6 +136,10 @@ class AuthBase(ABC):
     def authenticate(self, **kwargs):
         pass
 
+    @abstractmethod
+    def user_info(self) -> UserInfo:
+        pass
+
 
 class NoAuth(AuthBase):
     """No-op authentication class."""
@@ -127,6 +155,9 @@ class NoAuth(AuthBase):
 
     def authenticate(self, **kwargs):
         pass
+
+    def user_info(self) -> UserInfo:
+        return UserInfo()
 
 
 class TokenAuth(AuthBase):
@@ -167,7 +198,7 @@ class TokenAuth(AuthBase):
             self._refresh_token = None
             self.refresh_expires = 0
 
-        self.access_token = None
+        self.access_token: str | None = None
         self.access_expires = 0
 
         # the command line tool adds a default handler to the root logger on runtime,
@@ -347,6 +378,19 @@ class TokenAuth(AuthBase):
             "Your MLflow login token is valid until %s UTC",
             expire_date.strftime("%Y-%m-%d %H:%M:%S"),
         )
+
+    def user_info(self) -> UserInfo:
+        """Get user info embedded in the access token."""
+        self.authenticate()
+
+        if not self.access_token:
+            return UserInfo()
+
+        try:
+            return UserInfo.from_jwt(self.access_token)
+        except Exception as e:
+            self.log.exception("Failed to decode access token.", exc_info=e)
+            return UserInfo()
 
     def _token_request(
         self,

--- a/tests/test_mlflow_auth.py
+++ b/tests/test_mlflow_auth.py
@@ -9,6 +9,8 @@
 
 from __future__ import annotations
 
+import base64
+import json
 import os
 import time
 
@@ -18,6 +20,7 @@ from anemoi.utils.mlflow.auth import NoAuth
 from anemoi.utils.mlflow.auth import ServerConfig
 from anemoi.utils.mlflow.auth import ServerStore
 from anemoi.utils.mlflow.auth import TokenAuth
+from anemoi.utils.mlflow.auth import UserInfo
 
 
 def mocks(
@@ -286,3 +289,32 @@ def test_utils_interface():
     from anemoi.utils.config import CONFIG_LOCK
 
     assert isinstance(CONFIG_LOCK, type(RLock()))
+
+
+def test_user_info(mocker: pytest.MockerFixture) -> None:
+    payload = {
+        "name": "John Anemoi",
+        "preferred_username": "anemoi1234",
+        "email": "john.anemoi@example.com",
+        # some extra fields that are present in a real payload that should be ignored
+        "exp": 1773999223,
+        "email_verified": True,
+    }
+    request = {"access_token": f"e30.{base64.b64encode(json.dumps(payload).encode()).decode()}.e30"}
+    mocks(mocker, token_request=request)
+
+    # auth enabled
+    auth = TokenAuth("https://test.url")
+    for info in (auth.user_info(), UserInfo.from_jwt(request["access_token"])):
+        assert info
+        assert info.name == payload["name"]
+        assert info.email == payload["email"]
+        assert info.username == payload["preferred_username"]
+
+    # auth disabled
+    auth = TokenAuth("https://test.url", enabled=False)
+    for info in (auth.user_info(), UserInfo()):
+        assert not info
+        assert info.name is None
+        assert info.email is None
+        assert info.username is None


### PR DESCRIPTION
## Description
Add a new public method to the mlflow authentication class: `user_info()`.

Extracts user information contained in the access token. At logging time we can then choose to log any of this information in the mlflow run to know its owner. 

Since this is a nice-to-have but not critical function, if something goes wrong, or if no token is available, an empty model is returned instead of crashing. The method will only raise an exception if the authenticate call fails due to a missing or incorrect refresh token. 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
