### PR TITLE
fix: first-time alias lookup for lazy factories

### DIFF
--- a/src/anemoi/utils/registry.py
+++ b/src/anemoi/utils/registry.py
@@ -247,12 +247,14 @@ class Registry(Generic[T]):
         """
 
         name = name.replace("_", "-")
+        # call self.factories to ensure loading before unaliasing
+        factories = self.factories
         name = self._unalias(name)
 
         if return_none:
-            return self.factories.get(name)
+            return factories.get(name)
 
-        factory = self.factories.get(name)
+        factory = factories.get(name)
         if factory is None:
 
             LOG.error(f"Cannot find '{name}' in {self.package}")

--- a/tests/dummy_registry/__init__.py
+++ b/tests/dummy_registry/__init__.py
@@ -1,0 +1,3 @@
+from anemoi.utils.registry import Registry
+
+registry = Registry("tests.dummy_registry")

--- a/tests/dummy_registry/factory.py
+++ b/tests/dummy_registry/factory.py
@@ -1,0 +1,8 @@
+from . import registry
+
+
+def factory():
+    return "success"
+
+
+registry.register("test-factory", factory, aliases=["test-alias"])

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -63,9 +63,9 @@ def test_registry() -> None:
 def test_registry_with_lazy_import_alias_first():
     from .dummy_registry import registry
 
-    # if alias lookup is first from a lazily imported factory, the registry will raise
-    with pytest.raises(ValueError, match="Cannot find 'test-alias'"):
-        assert registry.lookup("test-alias")
+    # regression test: previously if alias lookup was the first access from a lazily imported factory,
+    # the registry would raise
+    assert registry.lookup("test-alias")() == "success"
 
 
 if __name__ == "__main__":

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -60,5 +60,13 @@ def test_registry() -> None:
         reg.lookup("fa")
 
 
+def test_registry_with_lazy_import_alias_first():
+    from .dummy_registry import registry
+
+    # if alias lookup is first from a lazily imported factory, the registry will raise
+    with pytest.raises(ValueError, match="Cannot find 'test-alias'"):
+        assert registry.lookup("test-alias")
+
+
 if __name__ == "__main__":
     test_registry()


### PR DESCRIPTION
## Description
When factories were added to the registry with aliases, if they were added in a way that their first lookup required loading the associated module, they raised a ValueError because the list of aliases was not populated. This PR fixes this problem and adds a regression test.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
