### PR TITLE
fix: only lookup git repo for editable dependencies

### DIFF
--- a/src/anemoi/utils/provenance.py
+++ b/src/anemoi/utils/provenance.py
@@ -34,58 +34,34 @@ LOG = logging.getLogger(__name__)
 
 
 def is_editable_install(init_path: str | Path) -> bool:
-    """Determine if a package is an editable install given its __init__.py path.
-
-    Returns True if the package appears to be an editable (development) install.
-
-    Parameters
-    ----------
-    init_path : str | Path
-        The path to the __init__.py file of the package.
-
-    Returns
-    -------
-    bool
-        True if the package appears to be an editable (development) install, False otherwise.
-
-    """
+    """Determine if the given path corresponds to an editable install."""
     init_path = Path(init_path).resolve()
-    package_dir = init_path.parent
 
-    # Find the matching distribution by comparing install paths
     for dist in importlib.metadata.distributions():
         try:
             direct_url_text = dist.read_text("direct_url.json")
-            if direct_url_text:
-                import json
+            if not direct_url_text:
+                continue
 
-                info = json.loads(direct_url_text)
-                # PEP 610: editable installs have {"dir_info": {"editable": true}}
-                if info.get("dir_info", {}).get("editable"):
-                    # Verify this dist actually corresponds to our package
-                    dist_top_level = _get_top_level_dir(dist)
-                    if dist_top_level and package_dir.is_relative_to(dist_top_level):
-                        return True
+            import json
+
+            info = json.loads(direct_url_text)
+            if not info.get("dir_info", {}).get("editable"):
+                continue
+
+            # The URL is the source directory of the editable install
+            url = info.get("url", "")
+            if not url.startswith("file://"):
+                continue
+
+            source_dir = Path(url[len("file://") :]).resolve()
+            if init_path.is_relative_to(source_dir):
+                return True
+
         except Exception:
             continue
 
     return False
-
-
-def _get_top_level_dir(dist) -> Path | None:
-    """Resolve the top-level source directory for a distribution."""
-    # Try top_level.txt first (older tooling like setuptools writes this)
-    top_level = dist.read_text("top_level.txt")
-    if top_level:
-        name = top_level.strip().splitlines()[0]
-        loc = dist.locate_file(name)
-        return Path(loc).resolve()
-
-    # Fall back to the dist's own location
-    if dist._path:
-        return Path(dist._path).parent.resolve()
-
-    return None
 
 
 def lookup_git_repo(path: str) -> Any | None:

--- a/src/anemoi/utils/provenance.py
+++ b/src/anemoi/utils/provenance.py
@@ -17,6 +17,7 @@
 """
 
 import datetime
+import importlib.metadata
 import json
 import logging
 import os
@@ -26,9 +27,65 @@ import sysconfig
 from functools import cache
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import distribution
+from pathlib import Path
 from typing import Any
 
 LOG = logging.getLogger(__name__)
+
+
+def is_editable_install(init_path: str | Path) -> bool:
+    """Determine if a package is an editable install given its __init__.py path.
+
+    Returns True if the package appears to be an editable (development) install.
+
+    Parameters
+    ----------
+    init_path : str | Path
+        The path to the __init__.py file of the package.
+
+    Returns
+    -------
+    bool
+        True if the package appears to be an editable (development) install, False otherwise.
+
+    """
+    init_path = Path(init_path).resolve()
+    package_dir = init_path.parent
+
+    # Find the matching distribution by comparing install paths
+    for dist in importlib.metadata.distributions():
+        try:
+            direct_url_text = dist.read_text("direct_url.json")
+            if direct_url_text:
+                import json
+
+                info = json.loads(direct_url_text)
+                # PEP 610: editable installs have {"dir_info": {"editable": true}}
+                if info.get("dir_info", {}).get("editable"):
+                    # Verify this dist actually corresponds to our package
+                    dist_top_level = _get_top_level_dir(dist)
+                    if dist_top_level and package_dir.is_relative_to(dist_top_level):
+                        return True
+        except Exception:
+            continue
+
+    return False
+
+
+def _get_top_level_dir(dist) -> Path | None:
+    """Resolve the top-level source directory for a distribution."""
+    # Try top_level.txt first (older tooling like setuptools writes this)
+    top_level = dist.read_text("top_level.txt")
+    if top_level:
+        name = top_level.strip().splitlines()[0]
+        loc = dist.locate_file(name)
+        return Path(loc).resolve()
+
+    # Fall back to the dist's own location
+    if dist._path:
+        return Path(dist._path).parent.resolve()
+
+    return None
 
 
 def lookup_git_repo(path: str) -> Any | None:
@@ -48,6 +105,9 @@ def lookup_git_repo(path: str) -> Any | None:
         from git import InvalidGitRepositoryError
         from git import Repo
     except ImportError:
+        return None
+
+    if not is_editable_install(path):
         return None
 
     while path != "/":

--- a/src/anemoi/utils/provenance.py
+++ b/src/anemoi/utils/provenance.py
@@ -33,33 +33,51 @@ from typing import Any
 LOG = logging.getLogger(__name__)
 
 
-def is_editable_install(init_path: str | Path) -> bool:
-    """Determine if the given path corresponds to an editable install."""
-    init_path = Path(init_path).resolve()
+@cache
+def editable_installs() -> dict[str, Path]:
+    """Return a dictionary of editable installs.
 
+    The check relies on how editable installs are handled based on PEP610.
+    A `<path-to-venv>/lib/site-packages/<package>.dist-info/direct_url.json`
+    file should be present.
+
+    Returns
+    -------
+    dict[str, Path]
+        A dictionary mapping package names to their source directories for editable installs.
+    """
+    installs = {}
     for dist in importlib.metadata.distributions():
         try:
             direct_url_text = dist.read_text("direct_url.json")
             if not direct_url_text:
                 continue
 
-            import json
-
             info = json.loads(direct_url_text)
             if not info.get("dir_info", {}).get("editable"):
                 continue
 
-            # The URL is the source directory of the editable install
             url = info.get("url", "")
             if not url.startswith("file://"):
                 continue
 
             source_dir = Path(url[len("file://") :]).resolve()
-            if init_path.is_relative_to(source_dir):
-                return True
+            installs[dist.metadata["Name"]] = source_dir
 
         except Exception:
             continue
+
+    return installs
+
+
+def is_editable_install(init_path: str | Path) -> bool:
+    """Determine if the given path corresponds to an editable install."""
+    init_path = Path(init_path).resolve()
+
+    for name, source_dir in editable_installs().items():
+        if init_path.is_relative_to(source_dir):
+            LOG.debug("Path %s is an editable install of %s", init_path, name)
+            return True
 
     return False
 

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -82,3 +82,239 @@ def test_get_package_source_url_nonexistent():
     """Test with a package that doesn't exist."""
     result = provenance._get_package_source_url("nonexistent-package-xyz-12345")
     assert result is None
+
+
+def test_is_editable_install_with_editable_package():
+    """Test is_editable_install() with a synthetic editable package.
+
+    Create a temporary package metadata directory that simulates an editable install.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a fake package directory (in site-packages location for dist-info)
+        site_packages = Path(tmpdir) / "site-packages"
+        site_packages.mkdir()
+
+        # Create dist-info for the editable package
+        dist_info = site_packages / "my_editable_package-1.0.0.dist-info"
+        dist_info.mkdir()
+
+        # Create METADATA file
+        metadata_content = """Metadata-Version: 2.1
+Name: my-editable-package
+Version: 1.0.0
+"""
+        (dist_info / "METADATA").write_text(metadata_content)
+
+        # Create direct_url.json with editable flag
+        direct_url_content = {
+            "url": f"file://{tmpdir}/src",
+            "dir_info": {"editable": True},
+        }
+        (dist_info / "direct_url.json").write_text(json.dumps(direct_url_content))
+
+        # Create top_level.txt pointing to the actual package name
+        (dist_info / "top_level.txt").write_text("my_editable_package\n")
+
+        # Create the actual package directory in site-packages
+        # (editable installs create a link/pth file pointing to the source)
+        package_dir = site_packages / "my_editable_package"
+        package_dir.mkdir()
+        init_file = package_dir / "__init__.py"
+        init_file.write_text("# Test package")
+
+        # Add site-packages to sys.path so importlib.metadata can discover it
+        sys.path.insert(0, str(site_packages))
+
+        try:
+            result = provenance.is_editable_install(str(init_file))
+            assert result is True, "Should detect editable install"
+        finally:
+            # Clean up
+            sys.path.remove(str(site_packages))
+
+
+def test_is_editable_install_with_regular_package():
+    """Test is_editable_install() with a regular (non-editable) package.
+
+    Create a temporary package metadata directory that simulates a regular install.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a fake site-packages directory
+        site_packages = Path(tmpdir) / "site-packages"
+        site_packages.mkdir()
+
+        # Create a fake package directory
+        package_dir = site_packages / "my_regular_package"
+        package_dir.mkdir(parents=True)
+        init_file = package_dir / "__init__.py"
+        init_file.write_text("# Test package")
+
+        # Create dist-info for the regular package
+        dist_info = site_packages / "my_regular_package-1.0.0.dist-info"
+        dist_info.mkdir()
+
+        # Create METADATA file
+        metadata_content = """Metadata-Version: 2.1
+Name: my-regular-package
+Version: 1.0.0
+"""
+        (dist_info / "METADATA").write_text(metadata_content)
+
+        # Regular packages don't have direct_url.json or have it without editable flag
+        # We'll test without direct_url.json (typical PyPI install)
+
+        # Create top_level.txt
+        (dist_info / "top_level.txt").write_text("my_regular_package\n")
+
+        # Add site-packages to sys.path so importlib.metadata can discover it
+        sys.path.insert(0, str(site_packages))
+
+        try:
+            result = provenance.is_editable_install(str(init_file))
+            assert result is False, "Should not detect regular install as editable"
+        finally:
+            # Clean up
+            sys.path.remove(str(site_packages))
+
+
+def test_is_editable_install_with_non_editable_direct_url():
+    """Test is_editable_install() with a package installed from git but not editable.
+
+    This simulates `pip install git+https://...` without -e flag.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a fake site-packages directory
+        site_packages = Path(tmpdir) / "site-packages"
+        site_packages.mkdir()
+
+        # Create a fake package directory
+        package_dir = site_packages / "my_git_package"
+        package_dir.mkdir(parents=True)
+        init_file = package_dir / "__init__.py"
+        init_file.write_text("# Test package")
+
+        # Create dist-info for the git package
+        dist_info = site_packages / "my_git_package-1.0.0.dist-info"
+        dist_info.mkdir()
+
+        # Create METADATA file
+        metadata_content = """Metadata-Version: 2.1
+Name: my-git-package
+Version: 1.0.0
+"""
+        (dist_info / "METADATA").write_text(metadata_content)
+
+        # Create direct_url.json without editable flag (git install but not editable)
+        direct_url_content = {
+            "url": "git+https://github.com/example/repo.git",
+            "vcs_info": {
+                "commit_id": "abc123",
+                "vcs": "git",
+            },
+        }
+        (dist_info / "direct_url.json").write_text(json.dumps(direct_url_content))
+
+        # Create top_level.txt
+        (dist_info / "top_level.txt").write_text("my_git_package\n")
+
+        # Add site-packages to sys.path so importlib.metadata can discover it
+        sys.path.insert(0, str(site_packages))
+
+        try:
+            result = provenance.is_editable_install(str(init_file))
+            assert result is False, "Should not detect git install without -e as editable"
+        finally:
+            # Clean up
+            sys.path.remove(str(site_packages))
+
+
+def test_is_editable_install_with_nonexistent_path():
+    """Test is_editable_install() with a path that doesn't exist."""
+    result = provenance.is_editable_install("/nonexistent/path/to/__init__.py")
+    assert result is False, "Should return False for nonexistent path"
+
+
+def test_get_top_level_dir_with_top_level_txt(mocker):
+    """Test _get_top_level_dir() when top_level.txt exists."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a fake site-packages directory
+        site_packages = Path(tmpdir) / "site-packages"
+        site_packages.mkdir()
+
+        # Create dist-info directory
+        dist_info = site_packages / "test_package-1.0.0.dist-info"
+        dist_info.mkdir()
+
+        # Create METADATA file
+        (dist_info / "METADATA").write_text("Metadata-Version: 2.1\nName: test-package\n")
+
+        # Create top_level.txt
+        (dist_info / "top_level.txt").write_text("test_package\n")
+
+        # Create the actual package directory
+        package_dir = site_packages / "test_package"
+        package_dir.mkdir()
+
+        # Add site-packages to sys.path
+        sys.path.insert(0, str(site_packages))
+
+        try:
+            from importlib.metadata import distribution
+
+            dist = distribution("test-package")
+            result = provenance._get_top_level_dir(dist)
+
+            assert result is not None, "Should return a path"
+            assert result.name == "test_package", "Should resolve to package directory"
+        finally:
+            sys.path.remove(str(site_packages))
+
+
+def test_lookup_git_repo_with_non_editable_package(mocker):
+    """Test that lookup_git_repo() returns None for non-editable packages.
+
+    This is the key behavior change - git repo lookup should only work for
+    editable installs.
+    """
+    # Mock is_editable_install to return False
+    mocker.patch("anemoi.utils.provenance.is_editable_install", return_value=False)
+
+    # Even if there's a git repo, it should return None for non-editable packages
+    result = provenance.lookup_git_repo("/some/path/to/package/__init__.py")
+
+    assert result is None, "Should return None for non-editable packages"
+
+
+def test_lookup_git_repo_with_editable_package_no_git(mocker):
+    """Test that lookup_git_repo() returns None for editable packages without git."""
+    # Mock is_editable_install to return True
+    mocker.patch("anemoi.utils.provenance.is_editable_install", return_value=True)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a fake package file (not in a git repo)
+        test_file = Path(tmpdir) / "test_package" / "__init__.py"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text("# Test")
+
+        result = provenance.lookup_git_repo(str(test_file))
+
+        assert result is None, "Should return None when no git repo is found"
+
+
+def test_lookup_git_repo_without_gitpython(mocker):
+    """Test that lookup_git_repo() returns None when GitPython is not available."""
+    # Mock the import to raise ImportError
+    import builtins
+
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "git":
+            raise ImportError("No module named 'git'")
+        return original_import(name, *args, **kwargs)
+
+    mocker.patch("builtins.__import__", side_effect=mock_import)
+
+    result = provenance.lookup_git_repo("/some/path")
+
+    assert result is None, "Should return None when GitPython is not available"

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -13,7 +13,15 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from anemoi.utils import provenance
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    provenance.editable_installs.cache_clear()
+    yield
 
 
 def test_gather() -> None:

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -85,51 +85,40 @@ def test_get_package_source_url_nonexistent():
 
 
 def test_is_editable_install_with_editable_package():
-    """Test is_editable_install() with a synthetic editable package.
-
-    Create a temporary package metadata directory that simulates an editable install.
-    """
+    """Test is_editable_install() with a synthetic editable package."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        # Create a fake package directory (in site-packages location for dist-info)
         site_packages = Path(tmpdir) / "site-packages"
         site_packages.mkdir()
+
+        # Create the source directory (what direct_url.json points to)
+        src_dir = Path(tmpdir) / "src"
+        src_dir.mkdir()
 
         # Create dist-info for the editable package
         dist_info = site_packages / "my_editable_package-1.0.0.dist-info"
         dist_info.mkdir()
 
-        # Create METADATA file
-        metadata_content = """Metadata-Version: 2.1
-Name: my-editable-package
-Version: 1.0.0
-"""
-        (dist_info / "METADATA").write_text(metadata_content)
+        (dist_info / "METADATA").write_text("Metadata-Version: 2.1\nName: my-editable-package\nVersion: 1.0.0\n")
 
-        # Create direct_url.json with editable flag
+        # direct_url.json points to the source directory
         direct_url_content = {
-            "url": f"file://{tmpdir}/src",
+            "url": f"file://{src_dir}",
             "dir_info": {"editable": True},
         }
         (dist_info / "direct_url.json").write_text(json.dumps(direct_url_content))
-
-        # Create top_level.txt pointing to the actual package name
         (dist_info / "top_level.txt").write_text("my_editable_package\n")
 
-        # Create the actual package directory in site-packages
-        # (editable installs create a link/pth file pointing to the source)
-        package_dir = site_packages / "my_editable_package"
+        # The actual package lives in the source directory, not site-packages
+        package_dir = src_dir / "my_editable_package"
         package_dir.mkdir()
         init_file = package_dir / "__init__.py"
         init_file.write_text("# Test package")
 
-        # Add site-packages to sys.path so importlib.metadata can discover it
         sys.path.insert(0, str(site_packages))
-
         try:
             result = provenance.is_editable_install(str(init_file))
             assert result is True, "Should detect editable install"
         finally:
-            # Clean up
             sys.path.remove(str(site_packages))
 
 
@@ -232,42 +221,6 @@ def test_is_editable_install_with_nonexistent_path():
     """Test is_editable_install() with a path that doesn't exist."""
     result = provenance.is_editable_install("/nonexistent/path/to/__init__.py")
     assert result is False, "Should return False for nonexistent path"
-
-
-def test_get_top_level_dir_with_top_level_txt(mocker):
-    """Test _get_top_level_dir() when top_level.txt exists."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # Create a fake site-packages directory
-        site_packages = Path(tmpdir) / "site-packages"
-        site_packages.mkdir()
-
-        # Create dist-info directory
-        dist_info = site_packages / "test_package-1.0.0.dist-info"
-        dist_info.mkdir()
-
-        # Create METADATA file
-        (dist_info / "METADATA").write_text("Metadata-Version: 2.1\nName: test-package\n")
-
-        # Create top_level.txt
-        (dist_info / "top_level.txt").write_text("test_package\n")
-
-        # Create the actual package directory
-        package_dir = site_packages / "test_package"
-        package_dir.mkdir()
-
-        # Add site-packages to sys.path
-        sys.path.insert(0, str(site_packages))
-
-        try:
-            from importlib.metadata import distribution
-
-            dist = distribution("test-package")
-            result = provenance._get_top_level_dir(dist)
-
-            assert result is not None, "Should return a path"
-            assert result.name == "test_package", "Should resolve to package directory"
-        finally:
-            sys.path.remove(str(site_packages))
 
 
 def test_lookup_git_repo_with_non_editable_package(mocker):


### PR DESCRIPTION
Closes #284

A simpler approach could be to check if `site-packages` is in the path of the package, however if the intent is to only get git version information for *editable dependencies*, the current solution is probably more robust.

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
