### PR TITLE
fix: fix and test make_int_list i/to/j/by/k

### DIFF
--- a/src/anemoi/utils/humanize.py
+++ b/src/anemoi/utils/humanize.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2024 Anemoi contributors.
+# (C) Copyright 2024-2026 Anemoi contributors.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -981,32 +981,47 @@ def print_dates(dates: list[datetime.datetime | str]) -> None:
 
 
 def make_list_int(value: str | list[int] | tuple[int] | int) -> list[int]:
-    """Convert a string like "1/2/3" or "1/to/3" or "1/to/10/by/2" to a list of integers.
+    """Convert a value to a list of integers.
+
+    Handles slash-separated strings including MARS-style range notation:
+    ``"1/2/3"``, ``"1/to/3"``, and ``"1/to/10/by/2"``.
 
     Parameters
     ----------
-    value : str, list, tuple, int
+    value : str, list, tuple, or int
         The value to convert to a list of integers.
 
     Returns
     -------
-    list
+    list[int]
         A list of integers.
+
+    Raises
+    ------
+    ValueError
+        If the value cannot be converted to a list of integers.
+
+    Examples
+    --------
+    >>> make_list_int("1/2/3")
+    [1, 2, 3]
+    >>> make_list_int("0/to/6")
+    [0, 1, 2, 3, 4, 5, 6]
+    >>> make_list_int("0/to/12/by/6")
+    [0, 6, 12]
     """
     if isinstance(value, str):
         if "/" not in value:
             return [int(value)]
         bits = value.split("/")
         if len(bits) == 3 and bits[1].lower() == "to":
-            value = list(range(int(bits[0]), int(bits[2]) + 1, 1))
+            return list(range(int(bits[0]), int(bits[2]) + 1))
+        if len(bits) == 5 and bits[1].lower() == "to" and bits[3].lower() == "by":
+            return list(range(int(bits[0]), int(bits[2]) + 1, int(bits[4])))
+        return [int(b) for b in bits]
 
-        elif len(bits) == 5 and bits[1].lower() == "to" and bits[3].lower() == "by":
-            value = list(range(int(bits[0]), int(bits[2]) + int(bits[4]), int(bits[4])))
-
-    if isinstance(value, list):
-        return value
-    if isinstance(value, tuple):
-        return value
+    if isinstance(value, (list, tuple)):
+        return list(value)
     if isinstance(value, int):
         return [value]
 

--- a/tests/test_humanize.py
+++ b/tests/test_humanize.py
@@ -11,6 +11,7 @@ import datetime
 
 import pytest
 
+from anemoi.utils.humanize import make_list_int
 from anemoi.utils.humanize import when
 
 UTC = datetime.timezone.utc
@@ -92,3 +93,60 @@ def test_when_future_values(delta, expected):
     """when() returns the correct human-readable string for future datetimes."""
     then = NOW_NAIVE + delta
     assert when(then, now=NOW_NAIVE) == expected
+
+
+# ---------------------------------------------------------------------------
+# make_list_int tests
+# ---------------------------------------------------------------------------
+
+
+def test_make_list_int_single_int():
+    assert make_list_int(42) == [42]
+
+
+def test_make_list_int_list_passthrough():
+    assert make_list_int([1, 2, 3]) == [1, 2, 3]
+
+
+def test_make_list_int_tuple():
+    assert make_list_int((1, 2, 3)) == [1, 2, 3]
+
+
+def test_make_list_int_single_string():
+    assert make_list_int("5") == [5]
+
+
+def test_make_list_int_slash_separated():
+    assert make_list_int("1/2/3") == [1, 2, 3]
+
+
+def test_make_list_int_to_range():
+    assert make_list_int("0/to/6") == [0, 1, 2, 3, 4, 5, 6]
+
+
+def test_make_list_int_to_range_inclusive_end():
+    """End value must be included even when it falls exactly on a step boundary."""
+    assert make_list_int("0/to/24") == list(range(0, 25))
+
+
+def test_make_list_int_to_by_range():
+    assert make_list_int("0/to/24/by/6") == [0, 6, 12, 18, 24]
+
+
+def test_make_list_int_to_by_inclusive_end():
+    """End value must be included when it falls exactly on a step boundary (bug fix)."""
+    assert make_list_int("0/to/12/by/6") == [0, 6, 12]
+
+
+def test_make_list_int_to_by_non_divisible_end():
+    """End value is not included when it does not fall on a step boundary."""
+    assert make_list_int("0/to/10/by/3") == [0, 3, 6, 9]
+
+
+def test_make_list_int_to_by_case_insensitive():
+    assert make_list_int("0/TO/12/BY/6") == [0, 6, 12]
+
+
+def test_make_list_int_invalid_raises():
+    with pytest.raises((ValueError, TypeError)):
+        make_list_int({"a": 1})


### PR DESCRIPTION
This fixes the corner case `make_list_int("0/to/10/by/3") == [0, 3, 6, 9]` instead of the currently wrong ` [0, 3, 6, 9, 12]` (most likely never happens but it is cleaner. And it adds tests.



***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
