### PR TITLE
fix(checkpoints): `_edit_metadata` multi-dataset supporting arrays

### DIFF
--- a/src/anemoi/utils/checkpoints.py
+++ b/src/anemoi/utils/checkpoints.py
@@ -292,17 +292,31 @@ def _edit_metadata(path: str, name: str, callback: Callable, supporting_arrays: 
     with zipfile.ZipFile(path, "r") as source_zip:
         file_list = source_zip.namelist()
 
-        # Calculate total files for progress bar
-        total_files = len(file_list)
+        # Build flat mapping of zip path -> array
+        array_paths = {}
         if supporting_arrays is not None:
-            total_files += len(supporting_arrays)
+            for key, entry in supporting_arrays.items():
+                if isinstance(entry, dict):
+                    # multi-dataset arrays are in a dataset subfolder
+                    for sub_key, sub_entry in entry.items():
+                        p = f"{key}/{sub_key}.numpy"
+                        array_paths[os.path.join(directory, p) if directory else p] = sub_entry
+                else:
+                    p = f"{key}.numpy"
+                    array_paths[os.path.join(directory, p) if directory else p] = entry
+
+        # Skip set for the copy loop
+        skip_paths = {target_file} | array_paths.keys()
+
+        # Calculate total files for progress bar
+        total_files = len(file_list) + len(array_paths)
 
         with zipfile.ZipFile(new_path, "w", zipfile.ZIP_STORED) as new_zip:
             with tqdm.tqdm(total=total_files, desc="Rebuilding checkpoint") as pbar:
 
-                # Copy all files except the target file
+                # Copy all files except those being replaced
                 for file_path in file_list:
-                    if file_path != target_file:
+                    if file_path not in skip_paths:
                         with source_zip.open(file_path) as source_file:
                             data = source_file.read()
                             new_zip.writestr(file_path, data)
@@ -323,11 +337,9 @@ def _edit_metadata(path: str, name: str, callback: Callable, supporting_arrays: 
                     pbar.update(1)
 
                 # Add supporting arrays if provided
-                if supporting_arrays is not None:
-                    for key, entry in supporting_arrays.items():
-                        array_path = os.path.join(directory, f"{key}.numpy") if directory else f"{key}.numpy"
-                        new_zip.writestr(array_path, entry.tobytes())
-                        pbar.update(1)
+                for array_path, array in array_paths.items():
+                    new_zip.writestr(array_path, array.tobytes())
+                    pbar.update(1)
 
     os.rename(new_path, path)
     LOG.info("Updated metadata in %s", path)

--- a/tests/test_checkpoints.py
+++ b/tests/test_checkpoints.py
@@ -123,6 +123,34 @@ class TestEditMetadata:
             np.testing.assert_array_equal(means_data, new_means)
             np.testing.assert_array_equal(stds_data, new_stds)
 
+    def test_edit_metadata_with_multi_dataset_supporting_arrays(self, sample_checkpoint):
+        """Test _edit_metadata with multi-dataset supporting arrays."""
+        arrays = {
+            "era5": {
+                "latitudes": np.array([1.0, 2.0, 3.0]),
+                "longitudes": np.array([4.0, 5.0, 6.0]),
+            },
+            "cerra": {
+                "latitudes": np.array([7.0, 8.0, 9.0]),
+                "longitudes": np.array([10.0, 11.0, 12.0]),
+            },
+        }
+
+        def noop(file_path):
+            pass
+
+        _edit_metadata(sample_checkpoint, "metadata.json", noop, supporting_arrays=arrays)
+
+        with zipfile.ZipFile(sample_checkpoint, "r") as zipf:
+            names = zipf.namelist()
+
+            for dataset, arrays in arrays.items():
+                for array_name, array in arrays.items():
+                    path = f"model/anemoi-metadata/{dataset}/{array_name}.numpy"
+                    assert path in names
+                    data = np.frombuffer(zipf.read(path), dtype=array.dtype)
+                    np.testing.assert_array_equal(data, array)
+
     def test_edit_metadata_preserves_other_files(self, sample_checkpoint):
         """Test that _edit_metadata preserves all other files in the ZIP."""
         with zipfile.ZipFile(sample_checkpoint, "r") as zipf:


### PR DESCRIPTION
## Description
In `checkpoints.py`, the `_edit_metadata()` , used by the public `replace_metadata()` was not updated to work with multi-dataset supporting arrays.

Also add a test for this case.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
