### PR TITLE
feat: optimise training speed when reading from s3 buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your functional changes to the appropriate section in the PR.
 Keep it human-readable, your future self will thank you!
 
-## Unreleased
-
-### Features
-
-* Use CLIENT_CACHE to avoid creating a new connection pool on every S3 read
-* Create obstore store intance once per bucket rather than on every call
-* Use obstore.get().bytes() to hand the entire fetch to Rust in one call
-* New get_objects_patallel function for parallel multistep reads
-
 ## [0.5.1](https://github.com/ecmwf/anemoi-utils/compare/0.5.0...0.5.1) (2026-03-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your functional changes to the appropriate section in the PR.
 Keep it human-readable, your future self will thank you!
 
+## Unreleased
+
+### Features
+
+* Use CLIENT_CACHE to avoid creating a new connection pool on every S3 read
+* Create obstore store intance once per bucket rather than on every call
+* Use obstore.get().bytes() to hand the entire fetch to Rust in one call
+* New get_objects_patallel function for parallel multistep reads
+
 ## [0.5.1](https://github.com/ecmwf/anemoi-utils/compare/0.5.0...0.5.1) (2026-03-17)
 
 

--- a/src/anemoi/utils/remote/s3.py
+++ b/src/anemoi/utils/remote/s3.py
@@ -29,6 +29,7 @@ import logging
 import os
 import threading
 from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 from typing import Any
 
@@ -51,6 +52,10 @@ MIGRATE = {
 
 CACHE = {}
 LOCK = threading.Lock()
+
+# Avoids creating a new connection pool on every S3 read during training.
+CLIENT_CACHE = {}
+CLIENT_LOCK = threading.Lock()
 
 
 class S3Object:
@@ -205,7 +210,7 @@ def _s3_options(obj: str | S3Object) -> dict:
 
 
 def s3_client(obj: str | S3Object) -> Any:
-    """Create an S3 client for the given URL.
+    """Return a cached S3 client for the given URL.
 
     Parameters
     ----------
@@ -221,9 +226,12 @@ def s3_client(obj: str | S3Object) -> Any:
     import obstore
 
     obj = _s3_object(obj)
-    options = _s3_options(obj)
-    LOG.debug(f"Using S3 options: {_hide_secrets(options)}")
-    return obstore.store.from_url(obj.dirname, **options)
+    with CLIENT_LOCK:
+        if obj.dirname not in CLIENT_CACHE:
+            options = _s3_options(obj)
+            LOG.debug(f"Using S3 options: {_hide_secrets(options)}")
+            CLIENT_CACHE[obj.dirname] = obstore.store.from_url(obj.dirname, **options)
+        return CLIENT_CACHE[obj.dirname]
 
 
 def upload_file(source: str, target: str, overwrite: bool, resume: bool, verbosity: int) -> int:
@@ -283,7 +291,7 @@ def upload_file(source: str, target: str, overwrite: bool, resume: bool, verbosi
         leave=verbosity >= 2,
         delay=0 if verbosity > 0 else 10,
     ) as pbar:
-        chunk_size = 1024 * 1024 * 10
+        chunk_size = 1024 * 1024 * 128
         total = size
         with open(source, "rb") as f:
             with closing(obstore.open_writer(s3, obj.key, buffer_size=chunk_size)) as g:
@@ -343,26 +351,28 @@ def download_file(source: str, target: str, overwrite: bool, resume: bool, verbo
     if os.path.exists(target) and not overwrite and not resume:
         raise ValueError(f"{target} already exists, use 'overwrite' to replace or 'resume' to skip")
 
-    with tqdm.tqdm(
-        desc=obj.key,
-        total=size,
-        unit="B",
-        unit_scale=True,
-        unit_divisor=1024,
-        leave=verbosity >= 2,
-        delay=0 if verbosity > 0 else 10,
-    ) as pbar:
-        chunk_size = 1024 * 1024 * 10
-        total = size
-        with closing(obstore.open_reader(s3, obj.key, buffer_size=chunk_size)) as f:
-            with open(target, "wb") as g:
-                while total > 0:
-                    chunk = f.read(min(chunk_size, total))
-                    g.write(chunk)
-                    pbar.update(len(chunk))
-                    total -= len(chunk)
+    last_exc = None
+    for attempt in range(3):
+        try:
+            with tqdm.tqdm(
+                desc=obj.key,
+                total=size,
+                unit="B",
+                unit_scale=True,
+                unit_divisor=1024,
+                leave=verbosity >= 2,
+                delay=0 if verbosity > 0 else 10,
+            ) as pbar:
+                data = obstore.get(s3, obj.key).bytes()
+                with open(target, "wb") as g:
+                    g.write(data)
+                pbar.update(size)
+            return size
+        except Exception as e:
+            last_exc = e
+            LOG.warning(f"Download attempt {attempt + 1}/3 failed for {source}: {e}")
 
-    return size
+    raise IOError(f"Failed to download {source} after 3 attempts: {last_exc}")
 
 
 def _list_objects(target: str, batch: bool = False) -> Iterable[list[dict]] | Iterable[dict]:
@@ -507,8 +517,8 @@ def object_exists(target: str) -> bool:
         return False
 
 
-def get_object(target: str) -> bool:
-    """Check if an S3 object exists.
+def get_object(target: str) -> bytes:
+    """Fetch an S3 object and return its contents as bytes.
 
     Parameters
     ----------
@@ -517,13 +527,43 @@ def get_object(target: str) -> bool:
 
     Returns
     -------
-    bool
-        True if object exists, False otherwise.
+    bytes
+        Object contents.
     """
     obj = _s3_object(target)
     s3 = s3_client(obj)
 
     return s3.get(obj.key).bytes()
+
+
+def get_objects_parallel(targets: list[str]) -> list[bytes]:
+    """Fetch multiple S3 objects concurrently and return their contents.
+
+    Parameters
+    ----------
+    targets : list[str]
+        List of S3 URLs to fetch in parallel.
+
+    Returns
+    -------
+    list[bytes]
+        Object contents in the same order as targets.
+    """
+
+    def _fetch(target: str) -> bytes:
+        obj = _s3_object(target)
+        s3 = s3_client(obj)
+        last_exc = None
+        for attempt in range(3):
+            try:
+                return s3.get(obj.key).bytes()
+            except Exception as e:
+                last_exc = e
+                LOG.warning(f"Fetch attempt {attempt + 1}/3 failed for {target}: {e}")
+        raise IOError(f"Failed to fetch {target} after 3 attempts: {last_exc}")
+
+    with ThreadPoolExecutor(max_workers=len(targets)) as ex:
+        return list(ex.map(_fetch, targets))
 
 
 def download(source: str, target: str, *args, **kwargs) -> None:

--- a/src/anemoi/utils/remote/s3.py
+++ b/src/anemoi/utils/remote/s3.py
@@ -291,7 +291,7 @@ def upload_file(source: str, target: str, overwrite: bool, resume: bool, verbosi
         leave=verbosity >= 2,
         delay=0 if verbosity > 0 else 10,
     ) as pbar:
-        chunk_size = 1024 * 1024 * 128
+        chunk_size = 1024 * 1024 * 10
         total = size
         with open(source, "rb") as f:
             with closing(obstore.open_writer(s3, obj.key, buffer_size=chunk_size)) as g:


### PR DESCRIPTION
Changes aimed at reducing overheads and allowing parallel reads.

## Description

#### CHANGE 1
`CLIENT_CACHE` stores the obstore client instance per bucket.
Avoids creating a new connection pool on every S3 read during training.

#### CHANGE 2
The original code created a new obstore store instance on every call, which initialises a new Rust connection pool each time. This is called once per chunk read during training (65,744 times for N320), making it a significant overhead. The fix creates the store once per bucket and reuses it across all reads. `CLIENT_LOCK` ensures thread safety across dataloader workers.

#### CHANGE 3 
The original code used `obstore.open_reader()` with a Python read loop, crossing the Python-Rust boundary on every 128 MB chunk read. For N320 chunks (~107 MB) this meant at least one Python-level blocking call per chunk. The fix uses `obstore.get().bytes()` which hands the entire fetch to Rust in one call. Rust assembles the complete object and returns it to Python once. This removes all Python read-loop overhead.

A retry loop (up to 3 attempts) is also added. If the Ceph RGW drops the connection mid-transfer under load, the download retries automatically rather than crashing the training run.

#### CHANGE 4
New function for parallel multistep reads. When anemoi reads multistep_input=2 consecutive timestep chunks per training step, the original code fetches them sequentially. This function fetches all chunks simultaneously using a thread pool, so the network time for both overlaps completely. For multistep_input=2 this roughly halves the I/O time per training step.

To activate this in training, the anemoi-training dataloader needs to call `get_objects_parallel()` instead of two separate `get_object()` calls. This function is ready to use and has been benchmarked at 969 MB/s vs 46 MB/s for the original sequential approach on ERA5 N320 chunks.

<!-- What issue or task does this change relate to? -->

## What problem does this change solve?
Significantly increases training speed when reading from an S3 bucket.
When training using the O48 dataset hosted at EWC, a speedup from 0.31 it/s to 0.79 it/s was seen representing an increase of over 150%.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
Also requires change to `anemoi-datasets` (https://github.com/ecmwf/anemoi-datasets) change to make use of `get_objects_parallel`

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
