### PR TITLE
fix: more robust s3 to process folders

### DIFF
--- a/src/anemoi/utils/remote/s3.py
+++ b/src/anemoi/utils/remote/s3.py
@@ -388,7 +388,8 @@ def _list_objects(target: str, batch: bool = False) -> Iterable[list[dict]] | It
 
     s3 = s3_client(obj)
 
-    for files in obstore.list(s3, obj.key + "/", chunk_size=1024):
+    prefix = obj.key.rstrip("/") + "/"
+    for files in obstore.list(s3, prefix, chunk_size=1024):
         if batch:
             yield files
         else:


### PR DESCRIPTION
The change is strictly defensive — it normalises the slash instead of blindly appending.



***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
