### PR TITLE
feat: more robust logs for registry

### DIFF
--- a/src/anemoi/utils/registry.py
+++ b/src/anemoi/utils/registry.py
@@ -171,7 +171,7 @@ class Registry(Generic[T]):
 
         if name in self.__registered:
             warnings.warn(f"Factory '{name}' is already registered in {self.package}")
-            warnings.warn(f"Existing: {self._sources[name]}")
+            warnings.warn(f"Existing: {self._sources.get(name, '<unknown>')}")
             warnings.warn(f"New: {source}")
 
         for alias in aliases:


### PR DESCRIPTION

This is an **AI-generated** bug fix. It seems harmless.

## What

Replace `self._sources[name]` with `self._sources.get(name, '<unknown>')` on the duplicate-registration warning path in `Registry.register`.

## Why

`Registry.register` warns when a factory name is registered twice and tries to print what was already there:

```python
if name in self.__registered:
    warnings.warn(f"Factory '{name}' is already registered in {self.package}")
    warnings.warn(f"Existing: {self._sources[name]}")   # ← crashes
    warnings.warn(f"New: {source}")
```

self.__registered and self._sources are only filled together at the bottom of register(), but __registered can also be populated through other paths (entry-point discovery, decorator-based registration in subclasses, …) without _sources being written. When that happens, the warning branch raises KeyError and a normally-benign duplicate registration becomes a hard failure.

This was observed via anemoi.transform.filters._merge_registries(): importing anemoi.transform.filters re-registers add-forcings into the central filter_registry, and the warning code crashed instead of emitting a warning. Downstream, this made from anemoi.datasets.dates.groups import Groups un-importable on anemoi-datasets main (where the new pydantic Action discriminator pulls in the filter registry at import time).

## Fix
One-line change: use dict.get with an <unknown> fallback so the warning still prints something useful even if _sources is out of sync.

The deeper question — why __registered and _sources can diverge in the first place — is left for a follow-up; this PR just keeps the warning warn-shaped instead of fatal.

## Test
No new test added; the change only affects a warning's repr payload. Manually verified that importing anemoi.transform.filters no longer raises KeyError: 'add-forcings'.


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
