### PR TITLE
feat: Add origin filtering to search parameters and tests

### DIFF
--- a/src/anemoi/utils/grib.py
+++ b/src/anemoi/utils/grib.py
@@ -19,11 +19,16 @@ import re
 import requests
 
 from .caching import cached
+from .config import load_config
 
 LOG = logging.getLogger(__name__)
+CONFIG = load_config().get("param_db", {})
+
+cache_length = CONFIG.get("cache_length", 30) * 24 * 60 * 60
+default_origin = CONFIG.get("default_origin", "ecmf")
 
 
-@cached(collection="grib", expires=30 * 24 * 60 * 60)
+@cached(collection="grib", expires=cache_length)
 def _units() -> dict[str, str]:
     """Fetch and cache GRIB parameter units.
 
@@ -38,14 +43,16 @@ def _units() -> dict[str, str]:
     return {str(u["id"]): u["name"] for u in units}
 
 
-@cached(collection="grib", expires=30 * 24 * 60 * 60)
-def _search_param(name: str) -> dict[str, str | int]:
+@cached(collection="grib", expires=cache_length)
+def _search_param(name: str, **filters) -> dict[str, str | int]:
     """Search for a GRIB parameter by name.
 
     Parameters
     ----------
     name : str
         Parameter name to search for.
+    filters : Any
+        Additional filters to disambiguate parameters with the same shortname (e.g. origin, encoding, table, discipline, category).
 
     Returns
     -------
@@ -57,8 +64,13 @@ def _search_param(name: str) -> dict[str, str | int]:
     KeyError
         If no parameter is found.
     """
+    if "origin" in filters and isinstance(filters["origin"], str):
+        filters["origin"] = _search_origin(filters["origin"])["id"]
+
     name = re.escape(name)
-    r = requests.get(f"https://codes.ecmwf.int/parameter-database/api/v1/param/?search=^{name}$&regex=true")
+    r = requests.get(
+        f"https://codes.ecmwf.int/parameter-database/api/v1/param/?search=^{name}$&regex=true{ ''.join(f'&{k}={v}' for k, v in filters.items()) }"
+    )
     r.raise_for_status()
     results = r.json()
     if len(results) == 0:
@@ -70,19 +82,63 @@ def _search_param(name: str) -> dict[str, str | int]:
         if len(dissemination) == 1:
             return dissemination[0]
 
+        LOG.warning(
+            f"{name} is ambiguous: {', '.join(names)}. Try filtering with 'origin','encoding','table','discipline' or 'category' to disambiguate."
+        )
+        if "origin" not in filters:
+            LOG.warning(f"Applying origin='{default_origin}' to disambiguate {name}.")
+            try:
+                return _search_param(name, **{**filters, "origin": default_origin})
+            except KeyError:
+                LOG.warning(
+                    f"Failed to disambiguate {name} with origin='{default_origin}'. Returning the first match: {names[0]}."
+                )
+
         results = sorted(results, key=lambda x: x["id"])
-        LOG.warning(f"{name} is ambiguous: {', '.join(names)}. Using param_id={results[0]['id']}")
 
     return results[0]
 
 
-def shortname_to_paramid(shortname: str) -> int:
+@cached(collection="grib", expires=30 * 24 * 60 * 60)
+def _search_origin(name: str) -> dict[str, str | int]:
+    """Search for an id of an origin by name.
+
+    Parameters
+    ----------
+    name : str
+        Origin name to search for.
+
+    Returns
+    -------
+    dict
+        A dictionary containing origin details.
+
+    Raises
+    ------
+    KeyError
+        If no origin is found.
+    """
+    name = re.escape(name)
+    r = requests.get("https://codes.ecmwf.int/parameter-database/api/v1/origin/")
+    r.raise_for_status()
+    results = r.json()
+
+    for result in results:
+        if result["abbreviation"] == name:
+            return result
+
+    raise KeyError(name)
+
+
+def shortname_to_paramid(shortname: str, **filters) -> int:
     """Return the GRIB parameter id given its shortname.
 
     Parameters
     ----------
     shortname : str
         Parameter shortname.
+    filters : Any
+        Additional filters to disambiguate parameters with the same shortname (e.g. origin, encoding, table, discipline, category).
 
     Returns
     -------
@@ -92,16 +148,18 @@ def shortname_to_paramid(shortname: str) -> int:
     >>> shortname_to_paramid("2t")
     167
     """
-    return _search_param(shortname)["id"]
+    return _search_param(shortname, **filters)["id"]
 
 
-def paramid_to_shortname(paramid: int) -> str:
+def paramid_to_shortname(paramid: int, **filters) -> str:
     """Return the shortname of a GRIB parameter given its id.
 
     Parameters
     ----------
     paramid : int
         Parameter id.
+    filters : Any
+        Additional filters to disambiguate parameters with the same shortname (e.g. origin, encoding, table, discipline, category).
 
     Returns
     -------
@@ -111,7 +169,7 @@ def paramid_to_shortname(paramid: int) -> str:
     >>> paramid_to_shortname(167)
     '2t'
     """
-    return _search_param(str(paramid))["shortname"]
+    return _search_param(str(paramid), **filters)["shortname"]
 
 
 def units(param: int | str) -> str:

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -1,0 +1,433 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Tests for grib.py — GRIB parameter lookup utilities.
+
+Covers the filtering/disambiguation logic added in the advanced-shortname-filtering
+feature, including origin-based filtering and default origin fallback.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(json_data, status_code=200):
+    """Create a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+# Sample API payloads -------------------------------------------------------
+
+PARAM_2T_ECMF = {
+    "id": 167,
+    "shortname": "2t",
+    "name": "2 metre temperature",
+    "unit_id": 1,
+    "access_ids": ["dissemination"],
+}
+
+PARAM_2T_OTHER = {
+    "id": 500167,
+    "shortname": "2t",
+    "name": "2 metre temperature (other centre)",
+    "unit_id": 1,
+    "access_ids": [],
+}
+
+PARAM_AMBIGUOUS_A = {
+    "id": 200,
+    "shortname": "xx",
+    "name": "Ambiguous param A",
+    "unit_id": 1,
+    "access_ids": [],
+}
+
+PARAM_AMBIGUOUS_B = {
+    "id": 300,
+    "shortname": "xx",
+    "name": "Ambiguous param B",
+    "unit_id": 1,
+    "access_ids": [],
+}
+
+ORIGIN_ECMF = {
+    "id": 98,
+    "abbreviation": "ecmf",
+    "name": "European Centre for Medium-Range Weather Forecasts",
+}
+ORIGIN_DESTINE = {
+    "id": -60,
+    "abbreviation": "destine",
+    "name": "Destination Earth Local parameter definitions",
+}
+
+ALL_ORIGINS = [ORIGIN_ECMF, ORIGIN_DESTINE]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — patch caching so every call goes straight through
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _bypass_cache(monkeypatch):
+    """Replace the @cached decorator with a no-op so tests hit the mocked API."""
+    import anemoi.utils.caching as caching_mod
+
+    def _noop_cached(*args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    monkeypatch.setattr(caching_mod, "cached", _noop_cached)
+
+    # Re-import the module so the patched decorator is applied
+    import importlib
+
+    import anemoi.utils.grib as grib_mod
+
+    importlib.reload(grib_mod)
+    yield
+    # Reload again to restore original state for other test modules
+    importlib.reload(grib_mod)
+
+
+def _grib():
+    """Import the reloaded grib module."""
+    import anemoi.utils.grib as grib_mod
+
+    return grib_mod
+
+
+# ---------------------------------------------------------------------------
+# Basic lookup tests
+# ---------------------------------------------------------------------------
+
+
+class TestShortNameToParamId:
+    """Tests for shortname_to_paramid."""
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_single_result(self, mock_get):
+        """A unique match returns the parameter id directly."""
+        mock_get.return_value = _mock_response([PARAM_2T_ECMF])
+
+        grib = _grib()
+        assert grib.shortname_to_paramid("2t") == 167
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_no_result_raises_key_error(self, mock_get):
+        """No matches should raise KeyError."""
+        mock_get.return_value = _mock_response([])
+
+        grib = _grib()
+        with pytest.raises(KeyError):
+            grib.shortname_to_paramid("nonexistent")
+
+
+class TestParamIdToShortName:
+    """Tests for paramid_to_shortname."""
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_single_result(self, mock_get):
+        """A unique match returns the shortname."""
+        mock_get.return_value = _mock_response([PARAM_2T_ECMF])
+
+        grib = _grib()
+        assert grib.paramid_to_shortname(167) == "2t"
+
+
+# ---------------------------------------------------------------------------
+# Disambiguation tests
+# ---------------------------------------------------------------------------
+
+
+class TestDisambiguationByDissemination:
+    """When multiple results exist, a single 'dissemination' entry wins."""
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_dissemination_filter_selects_correct_entry(self, mock_get):
+        """If exactly one result has 'dissemination' access, it is returned."""
+        # The correct entry (PARAM_2T_ECMF) is second in the response list
+        mock_get.return_value = _mock_response([PARAM_2T_OTHER, PARAM_2T_ECMF])
+
+        grib = _grib()
+        result = grib.shortname_to_paramid("2t")
+        assert result == 167, (
+            "Should pick the entry with 'dissemination' access (id=167), " "not the first entry (id=500167)"
+        )
+
+
+class TestDisambiguationByDefaultOrigin:
+    """When dissemination doesn't resolve ambiguity, default_origin is applied."""
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_default_origin_applied_when_ambiguous(self, mock_get):
+        """Two results, neither with dissemination → falls back to default_origin filter.
+
+        The second API call (with origin filter) returns the correct single match.
+        """
+
+        # First call: ambiguous, two results without dissemination
+        # Second call (with origin): returns only the correct one
+        # Third call: origin lookup
+        def side_effect(url, **kwargs):
+            if "origin/" in url:
+                return _mock_response(ALL_ORIGINS)
+            if "origin=" in url:
+                # Filtered call returns the correct entry only
+                return _mock_response([PARAM_AMBIGUOUS_A])
+            # Unfiltered call returns ambiguous results
+            return _mock_response([PARAM_AMBIGUOUS_B, PARAM_AMBIGUOUS_A])
+
+        mock_get.side_effect = side_effect
+
+        grib = _grib()
+        result = grib.shortname_to_paramid("xx")
+        # The default_origin filter resolves to PARAM_AMBIGUOUS_A (id=200)
+        assert result == 200
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_default_origin_fallback_to_sorted_first(self, mock_get):
+        """If default_origin also fails (KeyError), returns sorted first result."""
+
+        def side_effect(url, **kwargs):
+            if "origin/" in url:
+                return _mock_response(ALL_ORIGINS)
+            if "origin=" in url:
+                # Origin filter yields nothing
+                return _mock_response([])
+            # Unfiltered: ambiguous
+            return _mock_response([PARAM_AMBIGUOUS_B, PARAM_AMBIGUOUS_A])
+
+        mock_get.side_effect = side_effect
+
+        grib = _grib()
+        # Should fall back to sorted-first → id 200 (PARAM_AMBIGUOUS_A)
+        result = grib.shortname_to_paramid("xx")
+        assert result == 200, "Should return the entry with the lowest id after sorting"
+
+
+# ---------------------------------------------------------------------------
+# Explicit filter tests
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitOriginFilter:
+    """Passing origin= explicitly should change the returned parameter."""
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_origin_filter_changes_returned_key(self, mock_get):
+        """Filtering by origin should return the correct entry even when it is
+        the second item in the unfiltered response.
+
+        This verifies that filtering by origin (and by extension the default
+        origin) correctly selects a different entry than a naive 'first result'
+        approach would.
+        """
+
+        def side_effect(url, **kwargs):
+            if "origin/" in url:
+                return _mock_response(ALL_ORIGINS)
+            if "origin=98" in url:
+                # When filtered by ecmf origin (id=98), only the ECMF entry
+                return _mock_response([PARAM_2T_ECMF])
+            if "origin=-60" in url:
+                # When filtered by destine origin (id=-60), only the other entry
+                return _mock_response([PARAM_2T_OTHER])
+            # Unfiltered
+            return _mock_response([PARAM_2T_OTHER, PARAM_2T_ECMF])
+
+        mock_get.side_effect = side_effect
+
+        grib = _grib()
+
+        # Without filter the correct entry (167) is the SECOND in the response.
+        # The dissemination filter would pick it, but with an explicit origin
+        # the API is called with origin= directly and returns only that entry.
+        result_ecmf = grib.shortname_to_paramid("2t")
+        assert (
+            result_ecmf == 167
+        ), "Filtering by nothing should return the ECMF entry with id 167, as it is set by default"
+
+        result_ecmf = grib.shortname_to_paramid("2t", origin="ecmf")
+        assert result_ecmf == 167
+
+        result_destine = grib.shortname_to_paramid("2t", origin="destine")
+        assert result_destine == 500167
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_origin_filter_not_reapplied_when_already_provided(self, mock_get):
+        """If the caller already passes origin=, the default_origin fallback
+        should NOT be applied on top of it.
+        """
+
+        def side_effect(url, **kwargs):
+            if "origin/" in url:
+                return _mock_response(ALL_ORIGINS)
+            # Even with origin filter, still ambiguous (edge case)
+            return _mock_response([PARAM_AMBIGUOUS_B, PARAM_AMBIGUOUS_A])
+
+        mock_get.side_effect = side_effect
+
+        grib = _grib()
+        result = grib.shortname_to_paramid("xx", origin="destine")
+        # Should NOT recurse with default_origin because origin was already
+        # provided. Falls through to sorted first → id 200.
+        assert result == 200
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_paramid_to_shortname_with_origin_filter(self, mock_get):
+        """paramid_to_shortname also forwards filters correctly."""
+
+        def side_effect(url, **kwargs):
+            if "origin/" in url:
+                return _mock_response(ALL_ORIGINS)
+            if "origin=" in url:
+                return _mock_response([PARAM_2T_ECMF])
+            return _mock_response([PARAM_2T_OTHER, PARAM_2T_ECMF])
+
+        mock_get.side_effect = side_effect
+
+        grib = _grib()
+        result = grib.paramid_to_shortname(167, origin="ecmf")
+        assert result == "2t"
+
+
+# ---------------------------------------------------------------------------
+# _search_origin tests
+# ---------------------------------------------------------------------------
+
+
+class TestSearchOrigin:
+    """Tests for the _search_origin helper."""
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_known_origin(self, mock_get):
+        mock_get.return_value = _mock_response(ALL_ORIGINS)
+
+        grib = _grib()
+        result = grib._search_origin("ecmf")
+        assert result["id"] == 98
+        assert result["abbreviation"] == "ecmf"
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_unknown_origin_raises_key_error(self, mock_get):
+        mock_get.return_value = _mock_response(ALL_ORIGINS)
+
+        grib = _grib()
+        with pytest.raises(KeyError):
+            grib._search_origin("zzzz")
+
+
+# ---------------------------------------------------------------------------
+# units / must_be_positive tests
+# ---------------------------------------------------------------------------
+
+
+class TestUnits:
+    """Tests for the units() and must_be_positive() helpers."""
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_units_returns_correct_string(self, mock_get):
+        unit_data = [{"id": 1, "name": "K"}, {"id": 2, "name": "m"}]
+
+        def side_effect(url, **kwargs):
+            if "unit/" in url:
+                return _mock_response(unit_data)
+            return _mock_response([PARAM_2T_ECMF])
+
+        mock_get.side_effect = side_effect
+
+        grib = _grib()
+        assert grib.units("2t") == "K"
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_must_be_positive(self, mock_get):
+        unit_data = [{"id": 1, "name": "K"}, {"id": 2, "name": "m"}]
+        param_tp = {**PARAM_2T_ECMF, "id": 228, "shortname": "tp", "unit_id": 2}
+
+        def side_effect(url, **kwargs):
+            if "unit/" in url:
+                return _mock_response(unit_data)
+            return _mock_response([param_tp])
+
+        mock_get.side_effect = side_effect
+
+        grib = _grib()
+        assert grib.must_be_positive("tp") is True
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_must_be_positive_false(self, mock_get):
+        unit_data = [{"id": 1, "name": "K"}]
+
+        def side_effect(url, **kwargs):
+            if "unit/" in url:
+                return _mock_response(unit_data)
+            return _mock_response([PARAM_2T_ECMF])
+
+        mock_get.side_effect = side_effect
+
+        grib = _grib()
+        assert grib.must_be_positive("2t") is False
+
+
+# ---------------------------------------------------------------------------
+# URL construction tests
+# ---------------------------------------------------------------------------
+
+
+class TestUrlConstruction:
+    """Verify that filter kwargs are appended to the API URL."""
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_filters_appended_to_url(self, mock_get):
+        mock_get.return_value = _mock_response([PARAM_2T_ECMF])
+
+        grib = _grib()
+        grib.shortname_to_paramid("2t", encoding=1, table=128)
+
+        call_url = mock_get.call_args[0][0]
+        assert "encoding=1" in call_url
+        assert "table=128" in call_url
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_origin_string_resolved_to_id_in_url(self, mock_get):
+        """When origin is a string, it should be resolved to a numeric id
+        via _search_origin before being appended to the URL.
+        """
+
+        def side_effect(url, **kwargs):
+            if "origin/" in url:
+                return _mock_response(ALL_ORIGINS)
+            return _mock_response([PARAM_2T_ECMF])
+
+        mock_get.side_effect = side_effect
+
+        grib = _grib()
+        grib.shortname_to_paramid("2t", origin="ecmf")
+
+        # Find the param search call (not the origin lookup)
+        param_calls = [c for c in mock_get.call_args_list if "param/" in str(c)]
+        assert len(param_calls) >= 1
+        param_url = param_calls[0][0][0]
+        assert "origin=98" in param_url, f"Expected origin to be resolved to numeric id 98, got URL: {param_url}"


### PR DESCRIPTION
This pull request enhances the flexibility and configurability of GRIB parameter lookups in the `src/anemoi/utils/grib.py` module. The main improvements include allowing additional filters for parameter searches, introducing configuration-driven defaults, and improving disambiguation logic for ambiguous parameter names.

**Configurability and Defaults:**
- Added support for loading configuration values for cache expiration (`cache_length`) and a default origin (`default_origin`) from the config file, making cache duration and disambiguation behavior easily adjustable.

**Enhanced Parameter Search and Disambiguation:**
- Modified `_search_param`, `shortname_to_paramid`, and `paramid_to_shortname` to accept additional keyword filters (such as `origin`, `encoding`, `table`, `discipline`, `category`) to better disambiguate parameters with the same shortname or ID. [[1]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2L41-R55) [[2]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2L95-R162) [[3]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2L114-R172)
- Improved the disambiguation process in `_search_param`: if a parameter is ambiguous and no origin is specified, the function now attempts to resolve ambiguity using the configured `default_origin`, logging helpful warnings throughout.

**Supporting Utilities:**
- Added a new cached function `_search_origin` to resolve origin names to IDs, supporting the improved disambiguation logic.

These changes together make parameter lookups more robust and adaptable to different datasets and user needs.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
