### PR TITLE
fix: Resolve deadlock and enhance parameter db lookup

### DIFF
--- a/src/anemoi/utils/caching.py
+++ b/src/anemoi/utils/caching.py
@@ -13,13 +13,13 @@ import json
 import os
 import time
 from collections.abc import Callable
-from threading import Lock
+from threading import RLock
 from typing import Any
 
 import numpy as np
 from filelock import FileLock
 
-LOCK = Lock()
+LOCK = RLock()
 CACHE = {}
 
 

--- a/src/anemoi/utils/grib.py
+++ b/src/anemoi/utils/grib.py
@@ -16,6 +16,7 @@ See https://codes.ecmwf.int/grib/param-db/ for more information.
 import json
 import logging
 import re
+import warnings
 
 import requests
 
@@ -25,12 +26,12 @@ from .config import load_config
 LOG = logging.getLogger(__name__)
 CONFIG = load_config().get("paramdb", {})
 
-cache_length = int(CONFIG.get("cache_length", 30)) * 24 * 60 * 60
-default_origin = CONFIG.get("default_origin", "ecmf")
-local_cache = CONFIG.get("local_cache", None)
+CACHE_LENGTH = int(CONFIG.get("CACHE_LENGTH", 30)) * 24 * 60 * 60
+DEFAULT_ORIGIN = CONFIG.get("DEFAULT_ORIGIN", "ecmf")
+LOCAL_CACHE = CONFIG.get("LOCAL_CACHE", None)
 
 
-@cached(collection="grib", expires=cache_length)
+@cached(collection="grib", expires=CACHE_LENGTH)
 def _units() -> dict[str, str]:
     """Fetch and cache GRIB parameter units.
 
@@ -65,14 +66,14 @@ def _local_search_param(name: str) -> list[dict[str, str | int | list[str]]]:
     KeyError
         If no parameter is found.
     """
-    local_param_db = json.load(open(local_cache))
+    local_param_db = json.load(open(LOCAL_CACHE))
     for param in local_param_db:
         if param["shortname"] == name:
             return [param]
     raise KeyError(f"{name} not found in local cache.")
 
 
-@cached(collection="grib", expires=cache_length)
+@cached(collection="grib", expires=CACHE_LENGTH)
 def _online_search_param(name: str, **filters) -> list[dict[str, str | int | list[str]]]:
     """Search for a GRIB parameter by name using the online API.
 
@@ -120,9 +121,9 @@ def _search_param(name: str, **filters) -> dict[str, str | int | list[str]]:
 
     name = re.escape(name)
 
-    if local_cache is not None:
+    if LOCAL_CACHE is not None:
         if filters:
-            LOG.warning("Filters are ignored when using local cache.")
+            warnings.warn("Filters are ignored when using local cache.")
         results = _local_search_param(name)
     else:
         results = _online_search_param(name, **filters)
@@ -136,16 +137,18 @@ def _search_param(name: str, **filters) -> dict[str, str | int | list[str]]:
         if len(dissemination) == 1:
             return dissemination[0]
 
-        LOG.warning(
-            f"{name} is ambiguous: {', '.join(names)}. Try filtering with 'origin','encoding','table','discipline' or 'category' to disambiguate."
-        )
+        warnings.warn(f"{name} is ambiguous: {', '.join(names)}.")
         if "origin" not in filters:
-            LOG.warning(f"Applying origin='{default_origin}' to disambiguate {name}.")
+            warnings.warn(f"Applying origin='{DEFAULT_ORIGIN}' to disambiguate {name}.")
             try:
-                return _search_param(name, **{**filters, "origin": default_origin})
+                filtered_param = _search_param(name, **{**filters, "origin": DEFAULT_ORIGIN})
+                warnings.warn(
+                    f"Disambiguated {name} to id: {filtered_param['id']} ({filtered_param.get('name', 'unknown')})."
+                )
+                return filtered_param
             except KeyError:
-                LOG.warning(
-                    f"Failed to disambiguate {name} with origin='{default_origin}'. Returning the first match: {names[0]}."
+                warnings.warn(
+                    f"Failed to disambiguate {name} with origin='{DEFAULT_ORIGIN}'. Returning the first match: {names[0]}."
                 )
 
         results = sorted(results, key=lambda x: x["id"])
@@ -167,7 +170,7 @@ def _search_origin_impl(name: str) -> dict[str, str | int]:
     raise KeyError(f"{name} not found in origin database.")
 
 
-@cached(collection="grib", expires=cache_length)
+@cached(collection="grib", expires=CACHE_LENGTH)
 def origin(name: str) -> dict[str, str | int]:
     """Search for an id of an origin by name.
 

--- a/src/anemoi/utils/grib.py
+++ b/src/anemoi/utils/grib.py
@@ -22,9 +22,9 @@ from .caching import cached
 from .config import load_config
 
 LOG = logging.getLogger(__name__)
-CONFIG = load_config().get("param_db", {})
+CONFIG = load_config().get("paramdb", {})
 
-cache_length = CONFIG.get("cache_length", 30) * 24 * 60 * 60
+cache_length = int(CONFIG.get("cache_length", 30)) * 24 * 60 * 60
 default_origin = CONFIG.get("default_origin", "ecmf")
 
 
@@ -64,12 +64,21 @@ def _search_param(name: str, **filters) -> dict[str, str | int]:
     KeyError
         If no parameter is found.
     """
+    return _search_param_impl(name, **filters)
+
+
+def _search_param_impl(name: str, **filters) -> dict[str, str | int]:
+    """Core implementation of _search_param, without caching.
+
+    Separated to avoid deadlock when the cached _search_param calls itself
+    recursively (the @cached decorator holds a lock).
+    """
     if "origin" in filters and isinstance(filters["origin"], str):
-        filters["origin"] = _search_origin(filters["origin"])["id"]
+        filters["origin"] = _search_origin_impl(filters["origin"])["id"]
 
     name = re.escape(name)
     r = requests.get(
-        f"https://codes.ecmwf.int/parameter-database/api/v1/param/?search=^{name}$&regex=true{ ''.join(f'&{k}={v}' for k, v in filters.items()) }"
+        f"https://codes.ecmwf.int/parameter-database/api/v1/param/?search=^{name}$&regex=true{''.join(f'&{k}={v}' for k, v in filters.items())}"
     )
     r.raise_for_status()
     results = r.json()
@@ -77,7 +86,7 @@ def _search_param(name: str, **filters) -> dict[str, str | int]:
         raise KeyError(name)
 
     if len(results) > 1:
-        names = [f'{r.get("id")} ({r.get("name")})' for r in results]
+        names = [f"{r.get('id')} ({r.get('name')})" for r in results]
         dissemination = [r for r in results if "dissemination" in r.get("access_ids", [])]
         if len(dissemination) == 1:
             return dissemination[0]
@@ -88,7 +97,7 @@ def _search_param(name: str, **filters) -> dict[str, str | int]:
         if "origin" not in filters:
             LOG.warning(f"Applying origin='{default_origin}' to disambiguate {name}.")
             try:
-                return _search_param(name, **{**filters, "origin": default_origin})
+                return _search_param_impl(name, **{**filters, "origin": default_origin})
             except KeyError:
                 LOG.warning(
                     f"Failed to disambiguate {name} with origin='{default_origin}'. Returning the first match: {names[0]}."
@@ -99,8 +108,22 @@ def _search_param(name: str, **filters) -> dict[str, str | int]:
     return results[0]
 
 
-@cached(collection="grib", expires=30 * 24 * 60 * 60)
-def _search_origin(name: str) -> dict[str, str | int]:
+def _search_origin_impl(name: str) -> dict[str, str | int]:
+    """Core implementation of _search_origin, without caching."""
+    name = re.escape(name)
+    r = requests.get("https://codes.ecmwf.int/parameter-database/api/v1/origin/")
+    r.raise_for_status()
+    results = r.json()
+
+    for result in results:
+        if result["abbreviation"] == name:
+            return result
+
+    raise KeyError(f"{name} not found in origin database.")
+
+
+@cached(collection="grib", expires=cache_length)
+def origin_to_id(name: str) -> dict[str, str | int]:
     """Search for an id of an origin by name.
 
     Parameters
@@ -118,16 +141,7 @@ def _search_origin(name: str) -> dict[str, str | int]:
     KeyError
         If no origin is found.
     """
-    name = re.escape(name)
-    r = requests.get("https://codes.ecmwf.int/parameter-database/api/v1/origin/")
-    r.raise_for_status()
-    results = r.json()
-
-    for result in results:
-        if result["abbreviation"] == name:
-            return result
-
-    raise KeyError(name)
+    return _search_origin_impl(name)
 
 
 def shortname_to_paramid(shortname: str, **filters) -> int:

--- a/src/anemoi/utils/grib.py
+++ b/src/anemoi/utils/grib.py
@@ -17,7 +17,6 @@ import json
 import logging
 import re
 import warnings
-from functools import cache
 
 import requests
 
@@ -118,7 +117,7 @@ def _search_param(name: str, **filters) -> dict[str, str | int | list[str]]:
         If no parameter is found.
     """
     if "origin" in filters and isinstance(filters["origin"], str):
-        filters["origin"] = _search_origin(filters["origin"])["id"]
+        filters["origin"] = origin(filters["origin"])["id"]
 
     name = re.escape(name)
 
@@ -157,21 +156,6 @@ def _search_param(name: str, **filters) -> dict[str, str | int | list[str]]:
     return results[0]
 
 
-@cache
-def _search_origin(name: str) -> dict[str, str | int]:
-    """Core implementation of _search_origin, without caching."""
-    name = re.escape(name)
-    r = requests.get("https://codes.ecmwf.int/parameter-database/api/v1/origin/")
-    r.raise_for_status()
-    results = r.json()
-
-    for result in results:
-        if result["abbreviation"] == name:
-            return result
-
-    raise KeyError(f"{name} not found in origin database.")
-
-
 @cached(collection="grib", expires=CACHE_LENGTH)
 def origin(name: str) -> dict[str, str | int]:
     """Search for an id of an origin by name.
@@ -191,7 +175,16 @@ def origin(name: str) -> dict[str, str | int]:
     KeyError
         If no origin is found.
     """
-    return _search_origin(name)
+    name = re.escape(name)
+    r = requests.get("https://codes.ecmwf.int/parameter-database/api/v1/origin/")
+    r.raise_for_status()
+    results = r.json()
+
+    for result in results:
+        if result["abbreviation"] == name:
+            return result
+
+    raise KeyError(f"{name} not found in origin database.")
 
 
 def shortname_to_paramid(shortname: str, **filters) -> int:

--- a/src/anemoi/utils/grib.py
+++ b/src/anemoi/utils/grib.py
@@ -17,6 +17,7 @@ import json
 import logging
 import re
 import warnings
+from functools import cache
 
 import requests
 
@@ -117,7 +118,7 @@ def _search_param(name: str, **filters) -> dict[str, str | int | list[str]]:
         If no parameter is found.
     """
     if "origin" in filters and isinstance(filters["origin"], str):
-        filters["origin"] = _search_origin_impl(filters["origin"])["id"]
+        filters["origin"] = _search_origin(filters["origin"])["id"]
 
     name = re.escape(name)
 
@@ -156,7 +157,8 @@ def _search_param(name: str, **filters) -> dict[str, str | int | list[str]]:
     return results[0]
 
 
-def _search_origin_impl(name: str) -> dict[str, str | int]:
+@cache
+def _search_origin(name: str) -> dict[str, str | int]:
     """Core implementation of _search_origin, without caching."""
     name = re.escape(name)
     r = requests.get("https://codes.ecmwf.int/parameter-database/api/v1/origin/")
@@ -189,7 +191,7 @@ def origin(name: str) -> dict[str, str | int]:
     KeyError
         If no origin is found.
     """
-    return _search_origin_impl(name)
+    return _search_origin(name)
 
 
 def shortname_to_paramid(shortname: str, **filters) -> int:

--- a/src/anemoi/utils/grib.py
+++ b/src/anemoi/utils/grib.py
@@ -26,9 +26,9 @@ from .config import load_config
 LOG = logging.getLogger(__name__)
 CONFIG = load_config().get("paramdb", {})
 
-CACHE_LENGTH = int(CONFIG.get("CACHE_LENGTH", 30)) * 24 * 60 * 60
-DEFAULT_ORIGIN = CONFIG.get("DEFAULT_ORIGIN", "ecmf")
-LOCAL_CACHE = CONFIG.get("LOCAL_CACHE", None)
+CACHE_LENGTH = int(CONFIG.get("cache_length", 30)) * 24 * 60 * 60
+DEFAULT_ORIGIN = CONFIG.get("default_origin", "ecmf")
+LOCAL_CACHE = CONFIG.get("local_cache", None)
 
 
 @cached(collection="grib", expires=CACHE_LENGTH)

--- a/src/anemoi/utils/grib.py
+++ b/src/anemoi/utils/grib.py
@@ -13,6 +13,7 @@
 See https://codes.ecmwf.int/grib/param-db/ for more information.
 """
 
+import json
 import logging
 import re
 
@@ -26,6 +27,7 @@ CONFIG = load_config().get("paramdb", {})
 
 cache_length = int(CONFIG.get("cache_length", 30)) * 24 * 60 * 60
 default_origin = CONFIG.get("default_origin", "ecmf")
+local_cache = CONFIG.get("local_cache", None)
 
 
 @cached(collection="grib", expires=cache_length)
@@ -43,8 +45,57 @@ def _units() -> dict[str, str]:
     return {str(u["id"]): u["name"] for u in units}
 
 
+def _local_search_param(name: str) -> list[dict[str, str | int | list[str]]]:
+    """Search for a GRIB parameter by name in the local cache.
+
+    This is used to avoid making API calls when the local cache is available.
+
+    Parameters
+    ----------
+    name : str
+        Parameter name to search for.
+
+    Returns
+    -------
+    list
+        A list of dictionaries containing parameter details.
+
+    Raises
+    ------
+    KeyError
+        If no parameter is found.
+    """
+    local_param_db = json.load(open(local_cache))
+    for param in local_param_db:
+        if param["shortname"] == name:
+            return [param]
+    raise KeyError(f"{name} not found in local cache.")
+
+
 @cached(collection="grib", expires=cache_length)
-def _search_param(name: str, **filters) -> dict[str, str | int]:
+def _online_search_param(name: str, **filters) -> list[dict[str, str | int | list[str]]]:
+    """Search for a GRIB parameter by name using the online API.
+
+    Parameters
+    ----------
+    name : str
+        Parameter name to search for.
+    filters : Any
+        Additional filters to disambiguate parameters with the same shortname (e.g. origin, encoding, table, discipline, category).
+
+    Returns
+    -------
+    list
+        A list of dictionaries containing parameter details.
+    """
+    r = requests.get(
+        f"https://codes.ecmwf.int/parameter-database/api/v1/param/?search=^{name}$&regex=true{''.join(f'&{k}={v}' for k, v in filters.items())}"
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def _search_param(name: str, **filters) -> dict[str, str | int | list[str]]:
     """Search for a GRIB parameter by name.
 
     Parameters
@@ -64,26 +115,20 @@ def _search_param(name: str, **filters) -> dict[str, str | int]:
     KeyError
         If no parameter is found.
     """
-    return _search_param_impl(name, **filters)
-
-
-def _search_param_impl(name: str, **filters) -> dict[str, str | int]:
-    """Core implementation of _search_param, without caching.
-
-    Separated to avoid deadlock when the cached _search_param calls itself
-    recursively (the @cached decorator holds a lock).
-    """
     if "origin" in filters and isinstance(filters["origin"], str):
         filters["origin"] = _search_origin_impl(filters["origin"])["id"]
 
     name = re.escape(name)
-    r = requests.get(
-        f"https://codes.ecmwf.int/parameter-database/api/v1/param/?search=^{name}$&regex=true{''.join(f'&{k}={v}' for k, v in filters.items())}"
-    )
-    r.raise_for_status()
-    results = r.json()
+
+    if local_cache is not None:
+        if filters:
+            LOG.warning("Filters are ignored when using local cache.")
+        results = _local_search_param(name)
+    else:
+        results = _online_search_param(name, **filters)
+
     if len(results) == 0:
-        raise KeyError(name)
+        raise KeyError(f"{name} not found in parameter database.")
 
     if len(results) > 1:
         names = [f"{r.get('id')} ({r.get('name')})" for r in results]
@@ -97,7 +142,7 @@ def _search_param_impl(name: str, **filters) -> dict[str, str | int]:
         if "origin" not in filters:
             LOG.warning(f"Applying origin='{default_origin}' to disambiguate {name}.")
             try:
-                return _search_param_impl(name, **{**filters, "origin": default_origin})
+                return _search_param(name, **{**filters, "origin": default_origin})
             except KeyError:
                 LOG.warning(
                     f"Failed to disambiguate {name} with origin='{default_origin}'. Returning the first match: {names[0]}."
@@ -123,7 +168,7 @@ def _search_origin_impl(name: str) -> dict[str, str | int]:
 
 
 @cached(collection="grib", expires=cache_length)
-def origin_to_id(name: str) -> dict[str, str | int]:
+def origin(name: str) -> dict[str, str | int]:
     """Search for an id of an origin by name.
 
     Parameters

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -15,6 +15,7 @@ feature, including origin-based filtering and default origin fallback.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -326,7 +327,7 @@ class TestSearchOrigin:
         mock_get.return_value = _mock_response(ALL_ORIGINS)
 
         grib = _grib()
-        result = grib._search_origin("ecmf")
+        result = grib.origin("ecmf")
         assert result["id"] == 98
         assert result["abbreviation"] == "ecmf"
 
@@ -336,7 +337,7 @@ class TestSearchOrigin:
 
         grib = _grib()
         with pytest.raises(KeyError):
-            grib._search_origin("zzzz")
+            grib.origin("zzzz")
 
 
 # ---------------------------------------------------------------------------
@@ -431,3 +432,202 @@ class TestUrlConstruction:
         assert len(param_calls) >= 1
         param_url = param_calls[0][0][0]
         assert "origin=98" in param_url, f"Expected origin to be resolved to numeric id 98, got URL: {param_url}"
+
+
+# ---------------------------------------------------------------------------
+# Local cache tests
+# ---------------------------------------------------------------------------
+
+# Minimal mock data modelled after parameters.json structure
+LOCAL_CACHE_DATA = [
+    {
+        "id": 1,
+        "name": "Stream function",
+        "shortname": "strf",
+        "unit_id": 1,
+        "encoding_ids": ["grib1", "grib2"],
+        "access_ids": ["dissemination"],
+        "published": True,
+        "pending": False,
+        "retired": False,
+    },
+    {
+        "id": 2,
+        "name": "Velocity potential",
+        "shortname": "vp",
+        "unit_id": 1,
+        "encoding_ids": ["grib1", "grib2"],
+        "access_ids": ["dissemination"],
+        "published": True,
+        "pending": False,
+        "retired": False,
+    },
+    {
+        "id": 10,
+        "name": "Wind speed",
+        "shortname": "ws",
+        "unit_id": 5,
+        "encoding_ids": ["grib1", "grib2"],
+        "access_ids": ["dissemination"],
+        "published": True,
+        "pending": False,
+        "retired": False,
+    },
+    {
+        "id": 31,
+        "name": "Sea ice area fraction",
+        "shortname": "ci",
+        "unit_id": 3,
+        "encoding_ids": ["grib1", "grib2"],
+        "access_ids": ["dissemination"],
+        "published": True,
+        "pending": False,
+        "retired": False,
+    },
+    {
+        "id": 34,
+        "name": "Sea surface temperature",
+        "shortname": "sst",
+        "unit_id": 2,
+        "encoding_ids": ["grib1", "grib2"],
+        "access_ids": ["dissemination"],
+        "published": True,
+        "pending": False,
+        "retired": False,
+    },
+    {
+        "id": 54,
+        "name": "Pressure",
+        "shortname": "pres",
+        "unit_id": 16,
+        "encoding_ids": ["grib1", "grib2"],
+        "access_ids": ["dissemination"],
+        "published": True,
+        "pending": False,
+        "retired": False,
+    },
+    {
+        "id": 59,
+        "name": "Convective available potential energy",
+        "shortname": "cape",
+        "unit_id": 17,
+        "encoding_ids": ["grib1", "grib2"],
+        "access_ids": [],
+        "published": True,
+        "pending": False,
+        "retired": False,
+    },
+]
+
+
+@pytest.fixture()
+def local_cache_file(tmp_path):
+    """Write LOCAL_CACHE_DATA to a temporary JSON file and return its path."""
+    cache_file = tmp_path / "parameters.json"
+    cache_file.write_text(json.dumps(LOCAL_CACHE_DATA))
+    return str(cache_file)
+
+
+class TestLocalCacheSearch:
+    """Tests for _local_search_param and the local_cache routing in _search_param."""
+
+    def test_local_search_param_returns_single_match(self, local_cache_file):
+        """_local_search_param returns a one-element list for a known shortname."""
+        grib = _grib()
+        orig = grib.local_cache
+        try:
+            grib.local_cache = local_cache_file
+            results = grib._local_search_param("sst")
+            assert len(results) == 1
+            assert results[0]["shortname"] == "sst"
+            assert results[0]["id"] == 34
+        finally:
+            grib.local_cache = orig
+
+    def test_local_search_param_raises_on_missing(self, local_cache_file):
+        """_local_search_param raises KeyError for an unknown shortname."""
+        grib = _grib()
+        orig = grib.local_cache
+        try:
+            grib.local_cache = local_cache_file
+            with pytest.raises(KeyError, match="not found in local cache"):
+                grib._local_search_param("nonexistent_param_xyz")
+        finally:
+            grib.local_cache = orig
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_search_param_local_cache_no_network(self, mock_get, local_cache_file):
+        """Verify requests.get is never called when local_cache is configured."""
+        grib = _grib()
+        orig = grib.local_cache
+        try:
+            grib.local_cache = local_cache_file
+            result = grib._search_param("ws")
+            mock_get.assert_not_called()
+            assert result["shortname"] == "ws"
+            assert result["id"] == 10
+        finally:
+            grib.local_cache = orig
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_shortname_to_paramid_via_local_cache(self, mock_get, local_cache_file):
+        """End-to-end: shortname_to_paramid works with the local cache."""
+        grib = _grib()
+        orig = grib.local_cache
+        try:
+            grib.local_cache = local_cache_file
+            assert grib.shortname_to_paramid("ci") == 31
+            assert grib.shortname_to_paramid("sst") == 34
+            assert grib.shortname_to_paramid("pres") == 54
+            mock_get.assert_not_called()
+        finally:
+            grib.local_cache = orig
+
+    @patch("anemoi.utils.grib.requests.get")
+    def test_paramid_to_shortname_via_local_cache(self, mock_get, local_cache_file):
+        """_search_param finds entries via local cache for reverse lookups."""
+        grib = _grib()
+        orig = grib.local_cache
+        try:
+            grib.local_cache = local_cache_file
+            result = grib._search_param("sst")
+            assert result["shortname"] == "sst"
+            mock_get.assert_not_called()
+        finally:
+            grib.local_cache = orig
+
+    def test_local_cache_filters_ignored_with_warning(self, local_cache_file):
+        """When local_cache is set, passing filters emits a warning."""
+        grib = _grib()
+        orig = grib.local_cache
+        try:
+            grib.local_cache = local_cache_file
+            with patch.object(grib.LOG, "warning") as mock_warn:
+                result = grib._search_param("sst", origin=98)
+                mock_warn.assert_called()
+                warning_msg = mock_warn.call_args[0][0]
+                assert "ignored" in warning_msg.lower() or "Filters" in warning_msg
+            assert result["id"] == 34
+        finally:
+            grib.local_cache = orig
+
+    def test_local_search_multiple_params(self, local_cache_file):
+        """Verify several known parameters from the mock cache are found."""
+        grib = _grib()
+        orig = grib.local_cache
+        try:
+            grib.local_cache = local_cache_file
+            expected = {
+                "strf": 1,
+                "vp": 2,
+                "ws": 10,
+                "cape": 59,
+            }
+            for shortname, expected_id in expected.items():
+                results = grib._local_search_param(shortname)
+                assert len(results) == 1
+                assert (
+                    results[0]["id"] == expected_id
+                ), f"Expected {shortname} -> id={expected_id}, got {results[0]['id']}"
+        finally:
+            grib.local_cache = orig

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -529,94 +529,94 @@ def local_cache_file(tmp_path):
 
 
 class TestLocalCacheSearch:
-    """Tests for _local_search_param and the local_cache routing in _search_param."""
+    """Tests for _local_search_param and the LOCAL_CACHE routing in _search_param."""
 
     def test_local_search_param_returns_single_match(self, local_cache_file):
         """_local_search_param returns a one-element list for a known shortname."""
         grib = _grib()
-        orig = grib.local_cache
+        orig = grib.LOCAL_CACHE
         try:
-            grib.local_cache = local_cache_file
+            grib.LOCAL_CACHE = local_cache_file
             results = grib._local_search_param("sst")
             assert len(results) == 1
             assert results[0]["shortname"] == "sst"
             assert results[0]["id"] == 34
         finally:
-            grib.local_cache = orig
+            grib.LOCAL_CACHE = orig
 
     def test_local_search_param_raises_on_missing(self, local_cache_file):
         """_local_search_param raises KeyError for an unknown shortname."""
         grib = _grib()
-        orig = grib.local_cache
+        orig = grib.LOCAL_CACHE
         try:
-            grib.local_cache = local_cache_file
+            grib.LOCAL_CACHE = local_cache_file
             with pytest.raises(KeyError, match="not found in local cache"):
                 grib._local_search_param("nonexistent_param_xyz")
         finally:
-            grib.local_cache = orig
+            grib.LOCAL_CACHE = orig
 
     @patch("anemoi.utils.grib.requests.get")
     def test_search_param_local_cache_no_network(self, mock_get, local_cache_file):
-        """Verify requests.get is never called when local_cache is configured."""
+        """Verify requests.get is never called when LOCAL_CACHE is configured."""
         grib = _grib()
-        orig = grib.local_cache
+        orig = grib.LOCAL_CACHE
         try:
-            grib.local_cache = local_cache_file
+            grib.LOCAL_CACHE = local_cache_file
             result = grib._search_param("ws")
             mock_get.assert_not_called()
             assert result["shortname"] == "ws"
             assert result["id"] == 10
         finally:
-            grib.local_cache = orig
+            grib.LOCAL_CACHE = orig
 
     @patch("anemoi.utils.grib.requests.get")
     def test_shortname_to_paramid_via_local_cache(self, mock_get, local_cache_file):
         """End-to-end: shortname_to_paramid works with the local cache."""
         grib = _grib()
-        orig = grib.local_cache
+        orig = grib.LOCAL_CACHE
         try:
-            grib.local_cache = local_cache_file
+            grib.LOCAL_CACHE = local_cache_file
             assert grib.shortname_to_paramid("ci") == 31
             assert grib.shortname_to_paramid("sst") == 34
             assert grib.shortname_to_paramid("pres") == 54
             mock_get.assert_not_called()
         finally:
-            grib.local_cache = orig
+            grib.LOCAL_CACHE = orig
 
     @patch("anemoi.utils.grib.requests.get")
     def test_paramid_to_shortname_via_local_cache(self, mock_get, local_cache_file):
         """_search_param finds entries via local cache for reverse lookups."""
         grib = _grib()
-        orig = grib.local_cache
+        orig = grib.LOCAL_CACHE
         try:
-            grib.local_cache = local_cache_file
+            grib.LOCAL_CACHE = local_cache_file
             result = grib._search_param("sst")
             assert result["shortname"] == "sst"
             mock_get.assert_not_called()
         finally:
-            grib.local_cache = orig
+            grib.LOCAL_CACHE = orig
 
-    def test_local_cache_filters_ignored_with_warning(self, local_cache_file):
-        """When local_cache is set, passing filters emits a warning."""
+    @patch("anemoi.utils.grib.warnings.warn")
+    def test_local_cache_filters_ignored_with_warning(self, mock_warning, local_cache_file):
+        """When LOCAL_CACHE is set, passing filters emits a warning."""
         grib = _grib()
-        orig = grib.local_cache
+        orig = grib.LOCAL_CACHE
         try:
-            grib.local_cache = local_cache_file
-            with patch.object(grib.LOG, "warning") as mock_warn:
-                result = grib._search_param("sst", origin=98)
-                mock_warn.assert_called()
-                warning_msg = mock_warn.call_args[0][0]
-                assert "ignored" in warning_msg.lower() or "Filters" in warning_msg
+            grib.LOCAL_CACHE = local_cache_file
+            result = grib._search_param("sst", origin=98)
+            mock_warning.assert_called()
+            warning_msg = mock_warning.call_args[0][0]
+            assert "ignored" in warning_msg.lower() or "Filters" in warning_msg
             assert result["id"] == 34
         finally:
-            grib.local_cache = orig
+            grib.LOCAL_CACHE = orig
 
     def test_local_search_multiple_params(self, local_cache_file):
         """Verify several known parameters from the mock cache are found."""
         grib = _grib()
-        orig = grib.local_cache
+        orig = grib.LOCAL_CACHE
         try:
-            grib.local_cache = local_cache_file
+            grib.LOCAL_CACHE = local_cache_file
             expected = {
                 "strf": 1,
                 "vp": 2,
@@ -630,4 +630,4 @@ class TestLocalCacheSearch:
                     results[0]["id"] == expected_id
                 ), f"Expected {shortname} -> id={expected_id}, got {results[0]['id']}"
         finally:
-            grib.local_cache = orig
+            grib.LOCAL_CACHE = orig


### PR DESCRIPTION
This pull request adds support for searching GRIB parameter metadata using a local cache file. The main logic in `grib.py` now checks for a configured local cache and uses it instead of making network requests. The tests have been expanded to cover local cache usage and ensure network calls are avoided when possible.

The most important changes are:

**Local cache support for parameter search:**

* Added a `local_cache` configuration option and logic to load and search a local JSON file for parameter metadata in `_local_search_param` and `_search_param`. When `local_cache` is set, parameter lookups are performed locally and network requests are skipped, with a warning if filters are provided [[1]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2L25-R30) [[2]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2R48-R98) [[3]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2L68-R134).
* Tests for local cache behavior were added, including fixtures to create temporary cache files and checks to ensure network calls are not made when the cache is used.


**Testing enhancements:**

* Added comprehensive tests for local cache search, error handling, and filter warnings, increasing coverage and robustness.

**Minor improvements:**

* Added missing imports and improved docstrings for clarity [[1]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2R16) [[2]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2R48-R98).

## Creating a local cache
```python
import requests

r = requests.get("https://codes.ecmwf.int/parameter-database/api/v1/param/?origin=98")
r.raise_for_status()
parameters = r.json()
print(len(parameters))

import json
json.dump(parameters, open("parameters.json", "w"), indent=2)
```

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
