### PR TITLE
feat: Add in-memory caching for local GRIB parameter database

### DIFF
--- a/src/anemoi/utils/grib.py
+++ b/src/anemoi/utils/grib.py
@@ -18,6 +18,7 @@ import logging
 import os
 import re
 import warnings
+from functools import cache
 
 import requests
 
@@ -85,6 +86,34 @@ def _units() -> dict[str, str]:
     return {str(u["id"]): u["name"] for u in units}
 
 
+@cache
+def _get_local_db(local_db: str) -> dict[str, dict[str, str | int | list[str]]]:
+    """Open the local GRIB parameter database.
+
+    Parameters
+    ----------
+    local_db : str
+        Path to the local cache file.
+
+    Returns
+    -------
+    dict
+        A dictionary mapping parameter shortnames to their details.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the local db file is not found.
+    """
+
+    if not os.path.exists(local_db):
+        raise FileNotFoundError(f"Local cache file {local_db} not found.")
+    raw_json = json.load(open(local_db, "r"))
+
+    return {r["shortname"]: r for r in raw_json}
+
+
+@cache
 def _local_search_param(name: str) -> list[dict[str, str | int | list[str]]]:
     """Search for a GRIB parameter by name in the local cache.
 
@@ -108,10 +137,10 @@ def _local_search_param(name: str) -> list[dict[str, str | int | list[str]]]:
     local_cache = GRIB_CONFIG.local_cache
     assert local_cache is not None, "Local cache is not configured."
 
-    local_param_db = json.load(open(local_cache, "r"))
-    for param in local_param_db:
-        if param["shortname"] == name:
-            return [param]
+    local_param_db = _get_local_db(local_cache)
+
+    if name in local_param_db:
+        return [local_param_db[name]]
     raise KeyError(f"{name} not found in local cache.")
 
 


### PR DESCRIPTION
## Description
This pull request improves the efficiency and reliability of local GRIB parameter database lookups in `src/anemoi/utils/grib.py` by introducing caching and refactoring the parameter search logic. The main changes are as follows:

**Performance and Reliability Improvements:**

* Added a new cached function `_get_local_db` to load and cache the local GRIB parameter database, reducing repeated file reads and improving performance.
* Updated `_local_search_param` to use `_get_local_db` for parameter lookups, simplifying the logic and ensuring faster repeated searches.
* Applied the `@cache` decorator from `functools` to both `_get_local_db` and `_local_search_param`, ensuring results are cached and reused. [[1]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2R21) [[2]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2R89-R116)

**Error Handling:**

* Added explicit error handling in `_get_local_db` to raise a `FileNotFoundError` if the local cache file does not exist, improving robustness.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
