### PR TITLE
fix: local grib param cache was secretly dropping entries

### DIFF
--- a/src/anemoi/utils/grib.py
+++ b/src/anemoi/utils/grib.py
@@ -87,7 +87,7 @@ def _units() -> dict[str, str]:
 
 
 @cache
-def _get_local_db(local_db: str) -> dict[str, dict[str, str | int | list[str]]]:
+def _get_local_db(local_db: str) -> list[dict[str, str | int | list[str]]]:
     """Open the local GRIB parameter database.
 
     Parameters
@@ -97,8 +97,8 @@ def _get_local_db(local_db: str) -> dict[str, dict[str, str | int | list[str]]]:
 
     Returns
     -------
-    dict
-        A dictionary mapping parameter shortnames to their details.
+    list[dict[str, str | int | list[str]]]
+        A list of dictionaries containing parameter details.
 
     Raises
     ------
@@ -108,9 +108,8 @@ def _get_local_db(local_db: str) -> dict[str, dict[str, str | int | list[str]]]:
 
     if not os.path.exists(local_db):
         raise FileNotFoundError(f"Local cache file {local_db} not found.")
-    raw_json = json.load(open(local_db, "r"))
 
-    return {r["shortname"]: r for r in raw_json}
+    return json.load(open(local_db, "r"))
 
 
 @cache
@@ -139,8 +138,10 @@ def _local_search_param(name: str) -> list[dict[str, str | int | list[str]]]:
 
     local_param_db = _get_local_db(local_cache)
 
-    if name in local_param_db:
-        return [local_param_db[name]]
+    matched_params = [param for param in local_param_db if param["shortname"] == name]
+    if matched_params:
+        return matched_params
+
     raise KeyError(f"{name} not found in local cache.")
 
 
@@ -209,8 +210,8 @@ def _search_param(name: str, **filters) -> dict[str, str | int | list[str]]:
             return dissemination[0]
 
         warnings.warn(f"{name} is ambiguous: {', '.join(names)}.")
-        if "origin" not in filters:
-            warnings.warn(f"Applying origin='{GRIB_CONFIG.default_origin}' to disambiguate {name}.")
+        if "origin" not in filters and GRIB_CONFIG.local_cache is None:
+            warnings.warn(f"Applying origin='{GRIB_CONFIG.default_origin}' in an attempt to disambiguate {name}.")
             try:
                 filtered_param = _search_param(name, **{**filters, "origin": GRIB_CONFIG.default_origin})
                 warnings.warn(
@@ -218,10 +219,9 @@ def _search_param(name: str, **filters) -> dict[str, str | int | list[str]]:
                 )
                 return filtered_param
             except KeyError:
-                warnings.warn(
-                    f"Failed to disambiguate {name} with origin='{GRIB_CONFIG.default_origin}'. Returning the first match: {names[0]}."
-                )
+                pass
 
+        warnings.warn(f"Failed to disambiguate {name}'. Returning the first match: {names[0]}.")
         results = sorted(results, key=lambda x: x["id"])
 
     return results[0]

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -16,6 +16,7 @@ feature, including origin-based filtering and default origin fallback.
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -26,6 +27,17 @@ from anemoi.utils.config import temporary_config
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _ensure_no_env():
+    """Ensure no environment variables are set that would interfere with tests."""
+    env_copy = os.environ.copy()
+    for key in list(env_copy.keys()):
+        if key.startswith("ANEMOI_CONFIG_PARAMDB_"):
+            os.environ.pop(key)
+    yield
+    os.environ.update(env_copy)
 
 
 def _mock_response(json_data, status_code=200):
@@ -205,7 +217,8 @@ class TestDisambiguationByDefaultOrigin:
         mock_get.side_effect = side_effect
 
         grib = _grib()
-        result = grib.shortname_to_paramid("xx")
+        with pytest.warns(UserWarning):
+            result = grib.shortname_to_paramid("xx")
         # The default_origin filter resolves to PARAM_AMBIGUOUS_A (id=200)
         assert result == 200
 
@@ -226,7 +239,8 @@ class TestDisambiguationByDefaultOrigin:
 
         grib = _grib()
         # Should fall back to sorted-first → id 200 (PARAM_AMBIGUOUS_A)
-        result = grib.shortname_to_paramid("xx")
+        with pytest.warns(UserWarning):
+            result = grib.shortname_to_paramid("xx")
         assert result == 200, "Should return the entry with the lowest id after sorting"
 
 
@@ -293,7 +307,8 @@ class TestExplicitOriginFilter:
         mock_get.side_effect = side_effect
 
         grib = _grib()
-        result = grib.shortname_to_paramid("xx", origin="destine")
+        with pytest.warns(UserWarning):
+            result = grib.shortname_to_paramid("xx", origin="destine")
         # Should NOT recurse with default_origin because origin was already
         # provided. Falls through to sorted first → id 200.
         assert result == 200
@@ -519,6 +534,17 @@ LOCAL_CACHE_DATA = [
         "pending": False,
         "retired": False,
     },
+    {
+        "id": 228059,
+        "name": "Convective available potential energy",
+        "shortname": "cape",
+        "unit_id": 17,
+        "encoding_ids": ["grib1", "grib2"],
+        "access_ids": [],
+        "published": True,
+        "pending": False,
+        "retired": False,
+    },
 ]
 
 
@@ -597,7 +623,6 @@ class TestLocalCacheSearch:
                 "strf": 1,
                 "vp": 2,
                 "ws": 10,
-                "cape": 59,
             }
             for shortname, expected_id in expected.items():
                 results = grib._local_search_param(shortname)
@@ -605,3 +630,22 @@ class TestLocalCacheSearch:
                 assert (
                     results[0]["id"] == expected_id
                 ), f"Expected {shortname} -> id={expected_id}, got {results[0]['id']}"
+
+    def test_local_search_matching_multiple_entries(self, local_cache_file):
+        """If multiple entries share the same shortname, all are returned."""
+        grib = _grib()
+        with temporary_config({"paramdb": {"local_cache": local_cache_file}}):
+            results = grib._local_search_param("cape")
+            assert len(results) == 2
+            ids = {r["id"] for r in results}  # type: ignore
+            assert ids == {59, 228059}, f"Expected to find both CAPE entries with ids 59 and 228059, got {ids}"
+
+    def test_smallest_id_returned_when_ambiguous_and_no_dissemination(self, local_cache_file):
+        """When multiple entries share a shortname and none have dissemination access, the one with the smallest id is returned."""
+        grib = _grib()
+        with temporary_config({"paramdb": {"local_cache": local_cache_file}}):
+            with pytest.warns(UserWarning):
+                result = grib.shortname_to_paramid("cape")
+            assert (
+                result == 59
+            ), f"Expected to return the entry with the smallest id (59) when multiple matches are found without dissemination access, got {result}"


### PR DESCRIPTION
## Description

> [!WARNING]
> Copilot summary of changes

This pull request refactors how the local GRIB parameter database is loaded and searched, improving support for cases where multiple entries share the same shortname. It also enhances ambiguity handling and expands test coverage to ensure correct behavior in these scenarios.

**Refactoring and improved handling of local parameter database:**
- Changed `_get_local_db` in `grib.py` to return a list of parameter dictionaries instead of a dict keyed by shortname, allowing multiple entries with the same shortname to coexist. Updated the docstring accordingly. [[1]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2L90-R90) [[2]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2L100-R101) [[3]](diffhunk://#diff-54c0a11e19eac491ef93d96d7d8303d6dd64fa02076199454e227f84906f47a2L111-R112)
- Updated `_local_search_param` to return all entries matching a given shortname, rather than just the first found, enabling correct handling when multiple parameters share a shortname.

**Ambiguity resolution and warning improvements:**
- Modified `_search_param` to only apply the default origin for disambiguation if no local cache is used, and improved warning messages to clarify fallback behavior when disambiguation fails.

**Testing enhancements:**
- Added a test fixture to ensure no interfering environment variables are set during tests.
- Added and updated tests to verify correct behavior when multiple local parameters share a shortname, including returning all matches and selecting the one with the smallest id when necessary. [[1]](diffhunk://#diff-d9f42dc5bca0922c82b771d1a88884ba1607b70cb72846ac41abd6fb5966a999R537-R547) [[2]](diffhunk://#diff-d9f42dc5bca0922c82b771d1a88884ba1607b70cb72846ac41abd6fb5966a999L600-R651)
- Updated tests to check for expected warnings during ambiguity resolution. [[1]](diffhunk://#diff-d9f42dc5bca0922c82b771d1a88884ba1607b70cb72846ac41abd6fb5966a999R220) [[2]](diffhunk://#diff-d9f42dc5bca0922c82b771d1a88884ba1607b70cb72846ac41abd6fb5966a999R242) [[3]](diffhunk://#diff-d9f42dc5bca0922c82b771d1a88884ba1607b70cb72846ac41abd6fb5966a999R310)

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
