### PR TITLE
fix(mlflow auth): Strip trailing slashes in server URL

### DIFF
--- a/src/anemoi/utils/mlflow/auth.py
+++ b/src/anemoi/utils/mlflow/auth.py
@@ -197,6 +197,8 @@ class TokenAuth(AuthBase):
         self.access_expires = 0
 
         self._enabled = enabled
+        self.target_env_var = target_env_var
+
         # the command line tool adds a default handler to the root logger on runtime,
         # so we init our logger here (on runtime, not on import) to avoid duplicate handlers
         self.log = logging.getLogger(__name__)
@@ -207,7 +209,6 @@ class TokenAuth(AuthBase):
             return
 
         self.url = url.rstrip("/")
-        self.target_env_var = target_env_var
 
         store = self._get_store()
         config = store.get(self.url)

--- a/src/anemoi/utils/mlflow/auth.py
+++ b/src/anemoi/utils/mlflow/auth.py
@@ -82,17 +82,17 @@ class ServerStore(RootModel):
     root: dict[str, ServerConfig] = {}
 
     def get(self, url: str) -> ServerConfig | None:
-        return self.root.get(url)
+        return self.root.get(url.rstrip("/"))
 
     def __getitem__(self, url: str) -> ServerConfig:
-        return self.root[url]
+        return self.root[url.rstrip("/")]
 
     def items(self):
         return self.root.items()
 
-    def update(self, url, config: ServerConfig) -> None:
+    def update(self, url: str, config: ServerConfig) -> None:
         """Update the server configuration for a given URL."""
-        self.root[url] = config
+        self.root[url.rstrip("/")] = config
 
     @property
     def servers(self) -> list[tuple[str, int]]:
@@ -115,6 +115,12 @@ class ServerStore(RootModel):
             _url = _data.pop("url")
             data = {_url: ServerConfig(**_data)}
         return data
+
+    @model_validator(mode="after")
+    def normalise_urls(self) -> ServerStore:
+        """Strip trailing slashes for pre-existing store entries."""
+        self.root = {url.rstrip("/"): cfg for url, cfg in self.root.items()}
+        return self
 
 
 class AuthBase(ABC):
@@ -184,7 +190,7 @@ class TokenAuth(AuthBase):
             by default `MLFLOW_TRACKING_TOKEN`
 
         """
-        self.url = url
+        self.url = url.rstrip("/")
         self.target_env_var = target_env_var
         self._enabled = enabled
 

--- a/src/anemoi/utils/mlflow/auth.py
+++ b/src/anemoi/utils/mlflow/auth.py
@@ -173,7 +173,7 @@ class TokenAuth(AuthBase):
 
     def __init__(
         self,
-        url: str,
+        url: str | None,
         enabled: bool = True,
         target_env_var: str = "MLFLOW_TRACKING_TOKEN",
     ) -> None:
@@ -181,7 +181,7 @@ class TokenAuth(AuthBase):
 
         Parameters
         ----------
-        url : str
+        url : str | None
             URL of the authentication server.
         enabled : bool, optional
             Set this to False to turn off authentication, by default True
@@ -190,7 +190,7 @@ class TokenAuth(AuthBase):
             by default `MLFLOW_TRACKING_TOKEN`
 
         """
-        self.url = url.rstrip("/")
+        self.url = url.rstrip("/") if url is not None else None
         self.target_env_var = target_env_var
         self._enabled = enabled
 

--- a/src/anemoi/utils/mlflow/auth.py
+++ b/src/anemoi/utils/mlflow/auth.py
@@ -190,9 +190,24 @@ class TokenAuth(AuthBase):
             by default `MLFLOW_TRACKING_TOKEN`
 
         """
-        self.url = url.rstrip("/") if url is not None else None
-        self.target_env_var = target_env_var
+        self._refresh_token = None
+        self.refresh_expires = 0
+
+        self.access_token: str | None = None
+        self.access_expires = 0
+
         self._enabled = enabled
+        # the command line tool adds a default handler to the root logger on runtime,
+        # so we init our logger here (on runtime, not on import) to avoid duplicate handlers
+        self.log = logging.getLogger(__name__)
+
+        if not url:
+            self.url = None
+            assert not enabled, "URL must be provided if authentication is enabled."
+            return
+
+        self.url = url.rstrip("/")
+        self.target_env_var = target_env_var
 
         store = self._get_store()
         config = store.get(self.url)
@@ -200,16 +215,6 @@ class TokenAuth(AuthBase):
         if config is not None:
             self._refresh_token = config.refresh_token
             self.refresh_expires = config.refresh_expires
-        else:
-            self._refresh_token = None
-            self.refresh_expires = 0
-
-        self.access_token: str | None = None
-        self.access_expires = 0
-
-        # the command line tool adds a default handler to the root logger on runtime,
-        # so we init our logger here (on runtime, not on import) to avoid duplicate handlers
-        self.log = logging.getLogger(__name__)
 
     def __call__(self) -> None:
         self.authenticate()

--- a/tests/test_mlflow_auth.py
+++ b/tests/test_mlflow_auth.py
@@ -280,6 +280,37 @@ def test_server_store() -> None:
     assert ServerStore({}).model_dump() == {}
 
 
+def test_normalise_urls() -> None:
+    """URLs with trailing slashes stored on disk should be normalised on load."""
+    config_with_slashes = {
+        "https://server-1.url/": {
+            "refresh_token": "refresh-token-1",
+            "refresh_expires": 1,
+        },
+        "https://server-2.url///": {
+            "refresh_token": "refresh-token-2",
+            "refresh_expires": 2,
+        },
+        "https://server-3.url": {
+            "refresh_token": "refresh-token-3",
+            "refresh_expires": 3,
+        },
+    }
+    store = ServerStore(config_with_slashes)
+
+    assert store.servers == [("https://server-3.url", 3), ("https://server-2.url", 2), ("https://server-1.url", 1)]
+
+    # getters should also accept slashed keys and resolve them correctly
+    assert store.get("https://server-1.url/") is not None
+    assert store.get("https://server-1.url/").refresh_token == "refresh-token-1"
+    assert store["https://server-3.url///"].refresh_token == "refresh-token-3"
+
+    # update() should normalise keys too
+    store.update("https://server-1.url/", ServerConfig(refresh_token="updated", refresh_expires=99))
+    assert store["https://server-1.url"].refresh_token == "updated"
+    assert store.get("https://server-1.url/").refresh_token == "updated"
+
+
 def test_utils_interface():
     """TokenAuth uses the utils CONFIG_LOCK when reading and writing the server store to ensure thread safety.
     Ensure that CONFIG_LOCK stays a reentrant lock, if it were a normal lock it would deadlock itself.


### PR DESCRIPTION
## Description
requests 2.34 stopped stripping trailing slashes in URLs. Our mlflow auth constructs URLs as `f"{self.url}/{path}"`. If a user-provided URL contains a trailing slash, the constructed path will have a double slash and fail.

requests<2.34 masked this behaviour. We should strip trailing slashes ourselves. 

https://github.com/psf/requests/pull/7315

## What issue or task does this change relate to?
#293

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
