### PR TITLE
refactor: Use metkit paramdb

### DIFF
--- a/docs/modules/settings.rst
+++ b/docs/modules/settings.rst
@@ -106,8 +106,12 @@ List fields are set as JSON-encoded arrays:
 
 .. code-block:: bash
 
-   # Change the default GRIB parameter origin
-   export ANEMOI_SETTINGS_PARAMDB__DEFAULT_ORIGIN="ecmf"
+   # Change the default filters
+   export ANEMOI_SETTINGS_PARAMDB__DEFAULT_FILTERS='{"origin":98}'
+
+   # Add context
+   export ANEMOI_SETTINGS_PARAMDB__DEFAULT_FILTERS='{"context": {"class":"ai","levtype":"sfc","type":"fc","stream":"oper"}}'
+
 
    # Extend the parameter cache lifetime to 90 days
    export ANEMOI_SETTINGS_PARAMDB__CACHE_LENGTH="90"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "peekle",
   "pydantic>=2.9",
   "pydantic-settings>=2.14.1",
+  "pymetkit",
   "python-dateutil",
   "pyyaml",
   "rich",

--- a/src/anemoi/utils/grib.py
+++ b/src/anemoi/utils/grib.py
@@ -16,24 +16,46 @@ Use `PARAMDB` for direct access.
 See https://codes.ecmwf.int/grib/param-db/ for more information.
 """
 
+import logging
 from datetime import timedelta
+from functools import cache
+from typing import Any
 
 from pymetkit import ParamDB
 
-from .settings import AnemoiSettings
+from .settings import SETTINGS
 
-SETTINGS = AnemoiSettings()
 """Anemoi settings, loaded on module import."""
 
-PARAMDB = ParamDB(
-    mode=SETTINGS.paramdb.mode,
-    cache_ttl=timedelta(days=SETTINGS.paramdb.cache_length),
-    yaml_path=SETTINGS.paramdb.local_data,
-)
+PARAMDB_SETTINGS = SETTINGS.paramdb
+LOG = logging.getLogger(__name__)
 
 
-def shortname_to_paramid(shortname: str, **filters) -> int:
+@cache
+def get_paramdb() -> ParamDB:
+    """Return the global ParamDB instance.
+
+    Returns
+    -------
+    ParamDB
+        The global ParamDB instance.
+    """
+
+    return ParamDB(
+        mode=PARAMDB_SETTINGS.mode,
+        cache_path=PARAMDB_SETTINGS.cache_path,
+        cache_ttl=timedelta(days=PARAMDB_SETTINGS.cache_length),
+        yaml_path=PARAMDB_SETTINGS.local_data,
+    )
+
+
+def shortname_to_paramid(shortname: str, **filters: Any) -> int:
     """Return the GRIB parameter id given its shortname.
+
+    SETTINGS.paramdb.default_filters can be used to provide default filters for disambiguation.
+
+    If a collision is detected (i.e. multiple parameters with the same shortname), a warning will be logged and the first parameter id will be returned.
+    Additional filters can be provided to disambiguate.
 
     Parameters
     ----------
@@ -50,18 +72,31 @@ def shortname_to_paramid(shortname: str, **filters) -> int:
     >>> shortname_to_paramid("2t")
     167
     """
-    return PARAMDB.shortname_to_param_id(shortname, **filters)
+    filters = filters or PARAMDB_SETTINGS.default_filters or {}
+
+    if get_paramdb().shortname_has_collisions(shortname) and not filters:
+        candidates = get_paramdb().shortname_to_param_id_candidates(shortname)
+        log_message = (
+            f"Shortname '{shortname}' has collisions. Candidates: {[c.param_id for c in candidates]}. "
+            "Consider providing additional filters to disambiguate, will use empty context by default."
+            f"\nTo select one of the ids use: \n"
+            + "\n".join(
+                f"  - {c.param_id}: {f'context = {c.mars_request_context}' if c.mars_request_context is not None else c.hard_filter_selector}"
+                for c in candidates
+            )
+        )
+        LOG.warning(log_message)
+        filters = {"context": {}}
+    return get_paramdb().shortname_to_param_id(shortname, **filters)
 
 
-def paramid_to_shortname(paramid: int, **filters) -> str:
+def paramid_to_shortname(paramid: int) -> str:
     """Return the shortname of a GRIB parameter given its id.
 
     Parameters
     ----------
     paramid : int
         Parameter id.
-    filters : Any
-        Additional filters to disambiguate parameters with the same shortname (e.g. origin, access, table, discipline, category).
 
     Returns
     -------
@@ -71,7 +106,7 @@ def paramid_to_shortname(paramid: int, **filters) -> str:
     >>> paramid_to_shortname(167)
     '2t'
     """
-    return PARAMDB.param_id_to_shortname(paramid, **filters)  # type: ignore[reportReturnType]
+    return get_paramdb().param_id_to_shortname(paramid)
 
 
 def units(param: int | str) -> str:
@@ -90,7 +125,7 @@ def units(param: int | str) -> str:
     >>> units(167)
     'K'
     """
-    return PARAMDB.get_units(param)
+    return get_paramdb().get_units(param)
 
 
 def must_be_positive(param: int | str) -> bool:

--- a/src/anemoi/utils/grib.py
+++ b/src/anemoi/utils/grib.py
@@ -10,212 +10,26 @@
 
 """Utilities for working with GRIB parameters.
 
+Aliases Pymetkit's ParamDB to provide a consistent interface for GRIB parameter lookups across Anemoi, with configuration controlled by Anemoi settings.
+Use `PARAMDB` for direct access.
+
 See https://codes.ecmwf.int/grib/param-db/ for more information.
 """
 
-import json
-import logging
-import os
-import re
-import warnings
-from functools import cache
+from datetime import timedelta
 
-import requests
+from pymetkit import ParamDB
 
-from .caching import cached
 from .settings import AnemoiSettings
-
-LOG = logging.getLogger(__name__)
 
 SETTINGS = AnemoiSettings()
 """Anemoi settings, loaded on module import."""
 
-
-@cached(collection="grib", expires=SETTINGS.paramdb.cache_length * 24 * 3600)
-def _units() -> dict[str, str]:
-    """Fetch and cache GRIB parameter units.
-
-    Returns
-    -------
-    dict
-        A dictionary mapping unit ids to their names.
-    """
-    r = requests.get("https://codes.ecmwf.int/parameter-database/api/v1/unit/")
-    r.raise_for_status()
-    units = r.json()
-    return {str(u["id"]): u["name"] for u in units}
-
-
-@cache
-def _get_local_db(local_db: str) -> list[dict[str, str | int | list[str]]]:
-    """Open the local GRIB parameter database.
-
-    Parameters
-    ----------
-    local_db : str
-        Path to the local cache file.
-
-    Returns
-    -------
-    list[dict[str, str | int | list[str]]]
-        A list of dictionaries containing parameter details.
-
-    Raises
-    ------
-    FileNotFoundError
-        If the local db file is not found.
-    """
-
-    if not os.path.exists(local_db):
-        raise FileNotFoundError(f"Local cache file {local_db} not found.")
-
-    return json.load(open(local_db, "r"))
-
-
-@cache
-def _local_search_param(name: str) -> list[dict[str, str | int | list[str]]]:
-    """Search for a GRIB parameter by name in the local cache.
-
-    This is used to avoid making API calls when the local cache is available.
-
-    Parameters
-    ----------
-    name : str
-        Parameter name to search for.
-
-    Returns
-    -------
-    list
-        A list of dictionaries containing parameter details.
-
-    Raises
-    ------
-    KeyError
-        If no parameter is found.
-    """
-    local_cache = SETTINGS.paramdb.local_cache
-    assert local_cache is not None, "Local cache is not configured."
-
-    local_param_db = _get_local_db(local_cache)
-
-    matched_params = [param for param in local_param_db if param["shortname"] == name]
-    if matched_params:
-        return matched_params
-
-    raise KeyError(f"{name} not found in local cache.")
-
-
-@cached(collection="grib", expires=SETTINGS.paramdb.cache_length * 24 * 3600)
-def _online_search_param(name: str, **filters) -> list[dict[str, str | int | list[str]]]:
-    """Search for a GRIB parameter by name using the online API.
-
-    Parameters
-    ----------
-    name : str
-        Parameter name to search for.
-    filters : Any
-        Additional filters to disambiguate parameters with the same shortname (e.g. origin, encoding, table, discipline, category).
-
-    Returns
-    -------
-    list
-        A list of dictionaries containing parameter details.
-    """
-    r = requests.get(
-        f"https://codes.ecmwf.int/parameter-database/api/v1/param/?search=^{name}$&regex=true{''.join(f'&{k}={v}' for k, v in filters.items())}"
-    )
-    r.raise_for_status()
-    return r.json()
-
-
-def _search_param(name: str, **filters) -> dict[str, str | int | list[str]]:
-    """Search for a GRIB parameter by name.
-
-    Parameters
-    ----------
-    name : str
-        Parameter name to search for.
-    filters : Any
-        Additional filters to disambiguate parameters with the same shortname (e.g. origin, encoding, table, discipline, category).
-
-    Returns
-    -------
-    dict
-        A dictionary containing parameter details.
-
-    Raises
-    ------
-    KeyError
-        If no parameter is found.
-    """
-    if "origin" in filters and isinstance(filters["origin"], str):
-        filters["origin"] = origin(filters["origin"])["id"]
-
-    name = re.escape(name)
-
-    if SETTINGS.paramdb.local_cache is not None:
-        if filters:
-            warnings.warn("Filters are ignored when using local cache.")
-        results = _local_search_param(name)
-    else:
-        results = _online_search_param(name, **filters)
-
-    if len(results) == 0:
-        raise KeyError(f"{name} not found in parameter database.")
-
-    if len(results) > 1:
-        names = [f"{r.get('id')} ({r.get('name')})" for r in results]
-        dissemination = [r for r in results if "dissemination" in r.get("access_ids", [])]  # type: ignore[reportOperatorIssue]
-        if len(dissemination) == 1:
-            return dissemination[0]
-
-        warnings.warn(f"{name} is ambiguous: {', '.join(names)}.")
-        if "origin" not in filters and SETTINGS.paramdb.local_cache is None:
-            warnings.warn(f"Applying origin='{SETTINGS.paramdb.default_origin}' in an attempt to disambiguate {name}.")
-            try:
-                filtered_param = _search_param(name, **{**filters, "origin": SETTINGS.paramdb.default_origin})
-                warnings.warn(
-                    f"Disambiguated {name} to id: {filtered_param['id']} ({filtered_param.get('name', 'unknown')})."
-                )
-                return filtered_param
-            except KeyError:
-                pass
-
-        warnings.warn(f"Failed to disambiguate {name}'. Returning the first match: {names[0]}.")
-        results = sorted(results, key=lambda x: x["id"])
-
-    return results[0]
-
-
-@cached(collection="grib", expires=SETTINGS.paramdb.cache_length * 24 * 3600)
-def origin(name: str) -> dict[str, str | int]:
-    """Search for an id of an origin by name.
-
-    Parameters
-    ----------
-    name : str
-        Origin name to search for.
-
-    Returns
-    -------
-    dict
-        A dictionary containing origin details.
-
-    Raises
-    ------
-    KeyError
-        If no origin is found.
-    """
-    name = re.escape(name)
-    r = requests.get("https://codes.ecmwf.int/parameter-database/api/v1/origin/")
-    r.raise_for_status()
-    results = r.json()
-
-    for result in results:
-        if result["abbreviation"] == name:
-            return result
-
-    raise KeyError(f"{name} not found in origin database.")
+PARAMDB = ParamDB(
+    mode=SETTINGS.paramdb.mode,
+    cache_ttl=timedelta(days=SETTINGS.paramdb.cache_length),
+    yaml_path=SETTINGS.paramdb.local_data,
+)
 
 
 def shortname_to_paramid(shortname: str, **filters) -> int:
@@ -226,7 +40,7 @@ def shortname_to_paramid(shortname: str, **filters) -> int:
     shortname : str
         Parameter shortname.
     filters : Any
-        Additional filters to disambiguate parameters with the same shortname (e.g. origin, encoding, table, discipline, category).
+        Additional filters to disambiguate parameters with the same shortname (e.g. origin, access, table).
 
     Returns
     -------
@@ -236,7 +50,7 @@ def shortname_to_paramid(shortname: str, **filters) -> int:
     >>> shortname_to_paramid("2t")
     167
     """
-    return _search_param(shortname, **filters)["id"]  # type: ignore[reportReturnType]
+    return PARAMDB.shortname_to_param_id(shortname, **filters)
 
 
 def paramid_to_shortname(paramid: int, **filters) -> str:
@@ -247,7 +61,7 @@ def paramid_to_shortname(paramid: int, **filters) -> str:
     paramid : int
         Parameter id.
     filters : Any
-        Additional filters to disambiguate parameters with the same shortname (e.g. origin, encoding, table, discipline, category).
+        Additional filters to disambiguate parameters with the same shortname (e.g. origin, access, table, discipline, category).
 
     Returns
     -------
@@ -257,7 +71,7 @@ def paramid_to_shortname(paramid: int, **filters) -> str:
     >>> paramid_to_shortname(167)
     '2t'
     """
-    return _search_param(str(paramid), **filters)["shortname"]  # type: ignore[reportReturnType]
+    return PARAMDB.param_id_to_shortname(paramid, **filters)  # type: ignore[reportReturnType]
 
 
 def units(param: int | str) -> str:
@@ -273,12 +87,10 @@ def units(param: int | str) -> str:
     str
         Parameter unit.
 
-    >>> unit(167)
+    >>> units(167)
     'K'
     """
-
-    unit_id = str(_search_param(str(param))["unit_id"])
-    return _units()[unit_id]
+    return PARAMDB.get_units(param)
 
 
 def must_be_positive(param: int | str) -> bool:

--- a/src/anemoi/utils/settings_schema/paramdb.py
+++ b/src/anemoi/utils/settings_schema/paramdb.py
@@ -7,9 +7,11 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from typing import Any
 from typing import Literal
 from typing import Optional
 
+from pydantic import Field
 from pydantic import FilePath
 
 from .base import AnemoiBaseSettingsSchema
@@ -26,8 +28,14 @@ class ParamDBConfig(AnemoiBaseSettingsSchema):
     mode: Literal["online", "offline"] = "offline"
     """Mode for GRIB parameter lookups. 'online' uses the ECMWF API, 'offline' uses a local cache file."""
 
+    cache_path: Optional[FilePath] = None
+    """Directory in which to store the cache file. Defaults to the OS-appropriate user cache directory (requires ``platformdirs``). Only relevant when ``mode="online"``.."""
+
     cache_length: int = 30
     """Cache length in days for GRIB parameter lookups."""
 
     local_data: Optional[FilePath] = None
     """Path to a local YAML cache file for GRIB parameters. If set, used instead of the online API."""
+
+    default_filters: dict[str, Any] | None = Field(default={"access": "dissemination"})
+    """Default filters to disambiguate GRIB parameters with the same shortname (e.g. origin, access, table, or context with class, type, stream, etc.)."""

--- a/src/anemoi/utils/settings_schema/paramdb.py
+++ b/src/anemoi/utils/settings_schema/paramdb.py
@@ -7,6 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+from typing import Literal
 from typing import Optional
 
 from pydantic import FilePath
@@ -22,11 +23,11 @@ class ParamDBConfig(AnemoiBaseSettingsSchema):
     and cache lifetime).
     """
 
-    default_origin: str = "ecmf"
-    """Default origin to use when disambiguating parameters with the same shortname."""
+    mode: Literal["online", "offline"] = "offline"
+    """Mode for GRIB parameter lookups. 'online' uses the ECMWF API, 'offline' uses a local cache file."""
 
     cache_length: int = 30
     """Cache length in days for GRIB parameter lookups."""
 
-    local_cache: Optional[FilePath] = None
-    """Path to a local JSON cache file for GRIB parameters. If set, used instead of the online API."""
+    local_data: Optional[FilePath] = None
+    """Path to a local YAML cache file for GRIB parameters. If set, used instead of the online API."""

--- a/src/anemoi/utils/settings_schema/settings.defaults.toml
+++ b/src/anemoi/utils/settings_schema/settings.defaults.toml
@@ -124,17 +124,16 @@ ignore_naming_conventions = false
 # =============================================================================
 [paramdb]
 
-# Default origin to use when disambiguating parameters with the same shortname.
-# Common values: "ecmf", "destine".
-default_origin = "ecmf"
+# Mode for GRIB parameter lookups. 'online' uses the ECMWF API, 'offline' uses a local cache file.
+mode = "offline"
 
-# Cache length in days for GRIB parameter lookups from the online API.
+# Cache length in days for GRIB parameter lookups.
 cache_length = 30
 
-# Path to a local JSON cache file for GRIB parameters.
-# If set, this will be used instead of making online API calls.
-# Leave empty / unset to use the online API.
-# local_cache = "/path/to/parameters.json"
+# Path to a local YAML cache file for GRIB parameters.
+# If set, used instead of the offline metkit cache.
+# Leave empty / unset to use the online / offline ECMWF API.
+# local_data = "/path/to/parameters.yaml"
 
 
 # =============================================================================

--- a/src/anemoi/utils/settings_schema/settings.defaults.toml
+++ b/src/anemoi/utils/settings_schema/settings.defaults.toml
@@ -127,6 +127,9 @@ ignore_naming_conventions = false
 # Mode for GRIB parameter lookups. 'online' uses the ECMWF API, 'offline' uses a local cache file.
 mode = "offline"
 
+# Path to store cached entries when using online mode, defaults to the OS-appropriate user cache directory
+# cache_path = "/tmp"
+
 # Cache length in days for GRIB parameter lookups.
 cache_length = 30
 
@@ -134,6 +137,14 @@ cache_length = 30
 # If set, used instead of the offline metkit cache.
 # Leave empty / unset to use the online / offline ECMWF API.
 # local_data = "/path/to/parameters.yaml"
+
+# Change the default filters to prevent conflicting shortname to paramid lookups
+# Default is access = "dissemination"
+# Set context with class, stream, type, or levtype
+# or origin, table, access directly
+
+[paramdb.default_filters]
+access = "dissemination"
 
 
 # =============================================================================

--- a/tests/parameter_metadata_test.yaml
+++ b/tests/parameter_metadata_test.yaml
@@ -1,0 +1,83 @@
+- id: 167
+  shortname: 2t
+  longname: 2 metre temperature
+  units: K
+  origin_ids: [98]
+  access_ids: [dissemination]
+
+- id: 228
+  shortname: tp
+  longname: Total precipitation
+  units: m
+  origin_ids: [98]
+  access_ids: [dissemination]
+
+- id: 130
+  shortname: t
+  longname: Temperature
+  units: K
+  origin_ids: [98]
+  access_ids: [dissemination]
+
+- id: 500014
+  shortname: t
+  longname: Temperature
+  units: K
+  origin_ids: [7]
+  access_ids: []
+
+- id: 134
+  shortname: sp
+  longname: Surface pressure
+  units: Pa
+  origin_ids: [98]
+  access_ids: [dissemination]
+
+- id: 151
+  shortname: msl
+  longname: Mean sea level pressure
+  units: Pa
+  origin_ids: [98]
+  access_ids: [dissemination]
+
+- id: 165
+  shortname: 10u
+  longname: 10 metre U wind component
+  units: m s**-1
+  origin_ids: [98]
+  access_ids: [dissemination]
+
+- id: 166
+  shortname: 10v
+  longname: 10 metre V wind component
+  units: m s**-1
+  origin_ids: [98]
+  access_ids: [dissemination]
+
+- id: 31
+  shortname: ci
+  longname: Sea ice area fraction
+  units: (0 - 1)
+  origin_ids: [98]
+  access_ids: [dissemination]
+
+- id: 260048
+  shortname: sf
+  longname: Snowfall
+  units: m of water equivalent
+  origin_ids: [98]
+  access_ids: [dissemination]
+
+- id: 59
+  shortname: cape
+  longname: Convective available potential energy
+  units: J kg**-1
+  origin_ids: [98]
+  access_ids: [dissemination]
+
+- id: 75
+  shortname: crwc
+  longname: Specific rain water content
+  units: kg kg**-1
+  origin_ids: [98]
+  access_ids: [dissemination]

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -19,9 +19,7 @@ Each test is parametrised over two ParamDB backends:
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 from pymetkit import ParamDB
@@ -32,45 +30,30 @@ from pymetkit import ParamDB
 
 FIXTURE_YAML = Path(__file__).parent / "parameter_metadata_test.yaml"
 
-_bundled_xfail = pytest.param(
-    "bundled",
-    marks=pytest.mark.xfail(
-        raises=FileNotFoundError,
-        reason="pymetkit bundled YAML not installed in this environment",
-        strict=False,
-    ),
-)
+
+@pytest.fixture(scope="session")
+def _local_paramdb():
+    return ParamDB(mode="offline", yaml_path=FIXTURE_YAML.resolve())
 
 
-@pytest.fixture(params=["local", _bundled_xfail])
-def grib(request, monkeypatch):
-    """Import anemoi.utils.grib and swap PARAMDB to the requested backend.
+@pytest.fixture(scope="session")
+def _offline_paramdb():
+    return ParamDB(mode="offline")
 
-    For 'local', the module is imported with settings pointing at our test
-    YAML. For 'bundled', PARAMDB is replaced with a ParamDB using pymetkit's
-    default YAML lookup (which may not exist).
+
+@pytest.fixture(params=["local", "bundled"])
+def grib(request, monkeypatch, _local_paramdb, _offline_paramdb):
+    """Swap anemoi.utils.grib.PARAMDB to the requested backend.
+
+    'local' reuses a session-scoped ParamDB pointing at our test YAML.
+    'bundled' constructs one from pymetkit's default YAML lookup (which may
+    not exist, in which case the test xfails on FileNotFoundError).
     """
-    from anemoi.utils.settings import AnemoiSettings
+    import anemoi.utils.grib as grib_mod
 
-    yaml_path = FIXTURE_YAML.resolve()
-    settings = AnemoiSettings()
-    settings.paramdb.local_data = yaml_path
-
-    # Ensure a clean import of the grib module with patched settings
-    cached = sys.modules.pop("anemoi.utils.grib", None)
-    try:
-        with patch("anemoi.utils.settings.AnemoiSettings", return_value=settings):
-            import anemoi.utils.grib as grib_mod
-
-        if request.param == "bundled":
-            bundled = ParamDB(mode="offline")
-            monkeypatch.setattr(grib_mod, "PARAMDB", bundled)
-
-        yield grib_mod
-    finally:
-        sys.modules.pop("anemoi.utils.grib", None)
-        if cached is not None:
-            sys.modules["anemoi.utils.grib"] = cached
+    db = _local_paramdb if request.param == "local" else _offline_paramdb
+    monkeypatch.setattr(grib_mod, "PARAMDB", db)
+    return grib_mod
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -7,630 +7,187 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Tests for grib.py — GRIB parameter lookup utilities.
+"""Tests for anemoi.utils.grib -- API consistency.
 
-Covers the filtering/disambiguation logic added in the advanced-shortname-filtering
-feature, including origin-based filtering and default origin fallback.
+Each test is parametrised over two ParamDB backends:
+
+- **local**: our own test YAML fixture -- always available.
+- **bundled**: pymetkit's shipped parameter_metadata.yaml.
+  Currently xfail because the YAML is not packaged with the dev install.
+  Will start passing (and enforcing) once pymetkit ships it.
 """
 
 from __future__ import annotations
 
-import json
-from contextlib import contextmanager
+import sys
 from pathlib import Path
-from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from pymetkit import ParamDB
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Fixtures
 # ---------------------------------------------------------------------------
 
+FIXTURE_YAML = Path(__file__).parent / "parameter_metadata_test.yaml"
 
-def _mock_response(json_data, status_code=200):
-    """Create a mock requests.Response."""
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.json.return_value = json_data
-    resp.raise_for_status.return_value = None
-    return resp
+_bundled_xfail = pytest.param(
+    "bundled",
+    marks=pytest.mark.xfail(
+        raises=FileNotFoundError,
+        reason="pymetkit bundled YAML not installed in this environment",
+        strict=False,
+    ),
+)
 
 
-# Sample API payloads -------------------------------------------------------
+@pytest.fixture(params=["local", _bundled_xfail])
+def grib(request, monkeypatch):
+    """Import anemoi.utils.grib and swap PARAMDB to the requested backend.
 
-PARAM_2T_ECMF = {
-    "id": 167,
-    "shortname": "2t",
-    "name": "2 metre temperature",
-    "unit_id": 1,
-    "access_ids": ["dissemination"],
-}
+    For 'local', the module is imported with settings pointing at our test
+    YAML. For 'bundled', PARAMDB is replaced with a ParamDB using pymetkit's
+    default YAML lookup (which may not exist).
+    """
+    from anemoi.utils.settings import AnemoiSettings
 
-PARAM_2T_OTHER = {
-    "id": 500167,
-    "shortname": "2t",
-    "name": "2 metre temperature (other centre)",
-    "unit_id": 1,
-    "access_ids": [],
-}
+    yaml_path = FIXTURE_YAML.resolve()
+    settings = AnemoiSettings()
+    settings.paramdb.local_data = yaml_path
 
-PARAM_AMBIGUOUS_A = {
-    "id": 200,
-    "shortname": "xx",
-    "name": "Ambiguous param A",
-    "unit_id": 1,
-    "access_ids": [],
-}
+    # Ensure a clean import of the grib module with patched settings
+    cached = sys.modules.pop("anemoi.utils.grib", None)
+    try:
+        with patch("anemoi.utils.settings.AnemoiSettings", return_value=settings):
+            import anemoi.utils.grib as grib_mod
 
-PARAM_AMBIGUOUS_B = {
-    "id": 300,
-    "shortname": "xx",
-    "name": "Ambiguous param B",
-    "unit_id": 1,
-    "access_ids": [],
-}
+        if request.param == "bundled":
+            bundled = ParamDB(mode="offline")
+            monkeypatch.setattr(grib_mod, "PARAMDB", bundled)
 
-ORIGIN_ECMF = {
-    "id": 98,
-    "abbreviation": "ecmf",
-    "name": "European Centre for Medium-Range Weather Forecasts",
-}
-ORIGIN_DESTINE = {
-    "id": -60,
-    "abbreviation": "destine",
-    "name": "Destination Earth Local parameter definitions",
-}
-
-ALL_ORIGINS = [ORIGIN_ECMF, ORIGIN_DESTINE]
+        yield grib_mod
+    finally:
+        sys.modules.pop("anemoi.utils.grib", None)
+        if cached is not None:
+            sys.modules["anemoi.utils.grib"] = cached
 
 
 # ---------------------------------------------------------------------------
-# Fixtures — patch caching so every call goes straight through
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture(autouse=True)
-def _bypass_cache(monkeypatch):
-    """Replace the @cached decorator with a no-op so tests hit the mocked API."""
-    import anemoi.utils.caching as caching_mod
-
-    def _noop_cached(*args, **kwargs):
-        def decorator(func):
-            return func
-
-        return decorator
-
-    monkeypatch.setattr(caching_mod, "cached", _noop_cached)
-
-    # Re-import the module so the patched decorator is applied
-    import importlib
-
-    import anemoi.utils.grib as grib_mod
-
-    importlib.reload(grib_mod)
-    yield
-    # Reload again to restore original state for other test modules
-    importlib.reload(grib_mod)
-
-
-def _grib():
-    """Import the reloaded grib module."""
-    import anemoi.utils.grib as grib_mod
-
-    return grib_mod
-
-
-# ---------------------------------------------------------------------------
-# Basic lookup tests
+# shortname_to_paramid
 # ---------------------------------------------------------------------------
 
 
 class TestShortNameToParamId:
-    """Tests for shortname_to_paramid."""
+    @pytest.mark.parametrize(
+        "shortname,expected_id",
+        [
+            ("2t", 167),
+            ("tp", 228),
+            ("sp", 134),
+            ("msl", 151),
+            ("ci", 31),
+        ],
+    )
+    def test_known_params(self, grib, shortname, expected_id):
+        result = grib.shortname_to_paramid(shortname)
+        assert result == expected_id
+        assert isinstance(result, int)
 
-    @patch("anemoi.utils.grib.requests.get")
-    def test_single_result(self, mock_get):
-        """A unique match returns the parameter id directly."""
-        mock_get.return_value = _mock_response([PARAM_2T_ECMF])
-
-        grib = _grib()
-        assert grib.shortname_to_paramid("2t") == 167
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_no_result_raises_key_error(self, mock_get):
-        """No matches should raise KeyError."""
-        mock_get.return_value = _mock_response([])
-
-        grib = _grib()
+    def test_unknown_raises_key_error(self, grib):
         with pytest.raises(KeyError):
-            grib.shortname_to_paramid("nonexistent")
+            grib.shortname_to_paramid("nonexistent_xyz")
+
+
+# ---------------------------------------------------------------------------
+# paramid_to_shortname
+# ---------------------------------------------------------------------------
 
 
 class TestParamIdToShortName:
-    """Tests for paramid_to_shortname."""
+    @pytest.mark.parametrize(
+        "paramid,expected_name",
+        [
+            (167, "2t"),
+            (228, "tp"),
+            (134, "sp"),
+            (151, "msl"),
+            (31, "ci"),
+        ],
+    )
+    def test_known_params(self, grib, paramid, expected_name):
+        result = grib.paramid_to_shortname(paramid)
+        assert result == expected_name
+        assert isinstance(result, str)
 
-    @patch("anemoi.utils.grib.requests.get")
-    def test_single_result(self, mock_get):
-        """A unique match returns the shortname."""
-        mock_get.return_value = _mock_response([PARAM_2T_ECMF])
-
-        grib = _grib()
-        assert grib.paramid_to_shortname(167) == "2t"
-
-
-# ---------------------------------------------------------------------------
-# Disambiguation tests
-# ---------------------------------------------------------------------------
-
-
-class TestDisambiguationByDissemination:
-    """When multiple results exist, a single 'dissemination' entry wins."""
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_dissemination_filter_selects_correct_entry(self, mock_get):
-        """If exactly one result has 'dissemination' access, it is returned."""
-        # The correct entry (PARAM_2T_ECMF) is second in the response list
-        mock_get.return_value = _mock_response([PARAM_2T_OTHER, PARAM_2T_ECMF])
-
-        grib = _grib()
-        result = grib.shortname_to_paramid("2t")
-        assert result == 167, (
-            "Should pick the entry with 'dissemination' access (id=167), " "not the first entry (id=500167)"
-        )
-
-
-class TestDisambiguationByDefaultOrigin:
-    """When dissemination doesn't resolve ambiguity, default_origin is applied."""
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_default_origin_applied_when_ambiguous(self, mock_get):
-        """Two results, neither with dissemination → falls back to default_origin filter.
-
-        The second API call (with origin filter) returns the correct single match.
-        """
-
-        # First call: ambiguous, two results without dissemination
-        # Second call (with origin): returns only the correct one
-        # Third call: origin lookup
-        def side_effect(url, **kwargs):
-            if "origin/" in url:
-                return _mock_response(ALL_ORIGINS)
-            if "origin=" in url:
-                # Filtered call returns the correct entry only
-                return _mock_response([PARAM_AMBIGUOUS_A])
-            # Unfiltered call returns ambiguous results
-            return _mock_response([PARAM_AMBIGUOUS_B, PARAM_AMBIGUOUS_A])
-
-        mock_get.side_effect = side_effect
-
-        grib = _grib()
-        with pytest.warns(UserWarning):
-            result = grib.shortname_to_paramid("xx")
-        # The default_origin filter resolves to PARAM_AMBIGUOUS_A (id=200)
-        assert result == 200
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_default_origin_fallback_to_sorted_first(self, mock_get):
-        """If default_origin also fails (KeyError), returns sorted first result."""
-
-        def side_effect(url, **kwargs):
-            if "origin/" in url:
-                return _mock_response(ALL_ORIGINS)
-            if "origin=" in url:
-                # Origin filter yields nothing
-                return _mock_response([])
-            # Unfiltered: ambiguous
-            return _mock_response([PARAM_AMBIGUOUS_B, PARAM_AMBIGUOUS_A])
-
-        mock_get.side_effect = side_effect
-
-        grib = _grib()
-        # Should fall back to sorted-first → id 200 (PARAM_AMBIGUOUS_A)
-        with pytest.warns(UserWarning):
-            result = grib.shortname_to_paramid("xx")
-        assert result == 200, "Should return the entry with the lowest id after sorting"
-
-
-# ---------------------------------------------------------------------------
-# Explicit filter tests
-# ---------------------------------------------------------------------------
-
-
-class TestExplicitOriginFilter:
-    """Passing origin= explicitly should change the returned parameter."""
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_origin_filter_changes_returned_key(self, mock_get):
-        """Filtering by origin should return the correct entry even when it is
-        the second item in the unfiltered response.
-
-        This verifies that filtering by origin (and by extension the default
-        origin) correctly selects a different entry than a naive 'first result'
-        approach would.
-        """
-
-        def side_effect(url, **kwargs):
-            if "origin/" in url:
-                return _mock_response(ALL_ORIGINS)
-            if "origin=98" in url:
-                # When filtered by ecmf origin (id=98), only the ECMF entry
-                return _mock_response([PARAM_2T_ECMF])
-            if "origin=-60" in url:
-                # When filtered by destine origin (id=-60), only the other entry
-                return _mock_response([PARAM_2T_OTHER])
-            # Unfiltered
-            return _mock_response([PARAM_2T_OTHER, PARAM_2T_ECMF])
-
-        mock_get.side_effect = side_effect
-
-        grib = _grib()
-
-        # Without filter the correct entry (167) is the SECOND in the response.
-        # The dissemination filter would pick it, but with an explicit origin
-        # the API is called with origin= directly and returns only that entry.
-        result_ecmf = grib.shortname_to_paramid("2t")
-        assert (
-            result_ecmf == 167
-        ), "Filtering by nothing should return the ECMF entry with id 167, as it is set by default"
-
-        result_ecmf = grib.shortname_to_paramid("2t", origin="ecmf")
-        assert result_ecmf == 167
-
-        result_destine = grib.shortname_to_paramid("2t", origin="destine")
-        assert result_destine == 500167
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_origin_filter_not_reapplied_when_already_provided(self, mock_get):
-        """If the caller already passes origin=, the default_origin fallback
-        should NOT be applied on top of it.
-        """
-
-        def side_effect(url, **kwargs):
-            if "origin/" in url:
-                return _mock_response(ALL_ORIGINS)
-            # Even with origin filter, still ambiguous (edge case)
-            return _mock_response([PARAM_AMBIGUOUS_B, PARAM_AMBIGUOUS_A])
-
-        mock_get.side_effect = side_effect
-
-        grib = _grib()
-        with pytest.warns(UserWarning):
-            result = grib.shortname_to_paramid("xx", origin="destine")
-        # Should NOT recurse with default_origin because origin was already
-        # provided. Falls through to sorted first → id 200.
-        assert result == 200
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_paramid_to_shortname_with_origin_filter(self, mock_get):
-        """paramid_to_shortname also forwards filters correctly."""
-
-        def side_effect(url, **kwargs):
-            if "origin/" in url:
-                return _mock_response(ALL_ORIGINS)
-            if "origin=" in url:
-                return _mock_response([PARAM_2T_ECMF])
-            return _mock_response([PARAM_2T_OTHER, PARAM_2T_ECMF])
-
-        mock_get.side_effect = side_effect
-
-        grib = _grib()
-        result = grib.paramid_to_shortname(167, origin="ecmf")
-        assert result == "2t"
-
-
-# ---------------------------------------------------------------------------
-# _search_origin tests
-# ---------------------------------------------------------------------------
-
-
-class TestSearchOrigin:
-    """Tests for the _search_origin helper."""
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_known_origin(self, mock_get):
-        mock_get.return_value = _mock_response(ALL_ORIGINS)
-
-        grib = _grib()
-        result = grib.origin("ecmf")
-        assert result["id"] == 98
-        assert result["abbreviation"] == "ecmf"
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_unknown_origin_raises_key_error(self, mock_get):
-        mock_get.return_value = _mock_response(ALL_ORIGINS)
-
-        grib = _grib()
+    def test_unknown_raises_key_error(self, grib):
         with pytest.raises(KeyError):
-            grib.origin("zzzz")
+            grib.paramid_to_shortname(9999999)
 
 
 # ---------------------------------------------------------------------------
-# units / must_be_positive tests
+# Roundtrip consistency
+# ---------------------------------------------------------------------------
+
+
+class TestRoundtripConsistency:
+    @pytest.mark.parametrize("shortname", ["2t", "tp", "sp", "msl", "10u", "10v"])
+    def test_shortname_roundtrip(self, grib, shortname):
+        paramid = grib.shortname_to_paramid(shortname)
+        assert grib.paramid_to_shortname(paramid) == shortname
+
+    @pytest.mark.parametrize("paramid", [167, 228, 134, 151, 165, 166])
+    def test_paramid_roundtrip(self, grib, paramid):
+        shortname = grib.paramid_to_shortname(paramid)
+        assert grib.shortname_to_paramid(shortname) == paramid
+
+
+# ---------------------------------------------------------------------------
+# units
 # ---------------------------------------------------------------------------
 
 
 class TestUnits:
-    """Tests for the units() and must_be_positive() helpers."""
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_units_returns_correct_string(self, mock_get):
-        unit_data = [{"id": 1, "name": "K"}, {"id": 2, "name": "m"}]
-
-        def side_effect(url, **kwargs):
-            if "unit/" in url:
-                return _mock_response(unit_data)
-            return _mock_response([PARAM_2T_ECMF])
-
-        mock_get.side_effect = side_effect
-
-        grib = _grib()
-        assert grib.units("2t") == "K"
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_must_be_positive(self, mock_get):
-        unit_data = [{"id": 1, "name": "K"}, {"id": 2, "name": "m"}]
-        param_tp = {**PARAM_2T_ECMF, "id": 228, "shortname": "tp", "unit_id": 2}
-
-        def side_effect(url, **kwargs):
-            if "unit/" in url:
-                return _mock_response(unit_data)
-            return _mock_response([param_tp])
-
-        mock_get.side_effect = side_effect
-
-        grib = _grib()
-        assert grib.must_be_positive("tp") is True
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_must_be_positive_false(self, mock_get):
-        unit_data = [{"id": 1, "name": "K"}]
-
-        def side_effect(url, **kwargs):
-            if "unit/" in url:
-                return _mock_response(unit_data)
-            return _mock_response([PARAM_2T_ECMF])
-
-        mock_get.side_effect = side_effect
-
-        grib = _grib()
-        assert grib.must_be_positive("2t") is False
+    @pytest.mark.parametrize(
+        "param,expected_unit",
+        [
+            ("2t", "K"),
+            ("tp", "m"),
+            ("sp", "Pa"),
+            ("10u", "m s**-1"),
+            (167, "K"),
+            (228, "m"),
+        ],
+    )
+    def test_known_units(self, grib, param, expected_unit):
+        result = grib.units(param)
+        assert result == expected_unit
+        assert isinstance(result, str)
 
 
 # ---------------------------------------------------------------------------
-# URL construction tests
+# must_be_positive
 # ---------------------------------------------------------------------------
 
 
-class TestUrlConstruction:
-    """Verify that filter kwargs are appended to the API URL."""
+class TestMustBePositive:
+    @pytest.mark.parametrize(
+        "param,expected",
+        [
+            ("tp", True),  # units: m
+            ("crwc", True),  # units: kg kg**-1
+            ("sf", True),  # units: m of water equivalent
+            ("2t", False),  # units: K
+            ("sp", False),  # units: Pa
+            ("10u", False),  # units: m s**-1
+            ("cape", False),  # units: J kg**-1
+        ],
+    )
+    def test_positive_classification(self, grib, param, expected):
+        result = grib.must_be_positive(param)
+        assert result is expected
+        assert isinstance(result, bool)
 
-    @patch("anemoi.utils.grib.requests.get")
-    def test_filters_appended_to_url(self, mock_get):
-        mock_get.return_value = _mock_response([PARAM_2T_ECMF])
-
-        grib = _grib()
-        grib.shortname_to_paramid("2t", encoding=1, table=128)
-
-        call_url = mock_get.call_args[0][0]
-        assert "encoding=1" in call_url
-        assert "table=128" in call_url
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_origin_string_resolved_to_id_in_url(self, mock_get):
-        """When origin is a string, it should be resolved to a numeric id
-        via _search_origin before being appended to the URL.
-        """
-
-        def side_effect(url, **kwargs):
-            if "origin/" in url:
-                return _mock_response(ALL_ORIGINS)
-            return _mock_response([PARAM_2T_ECMF])
-
-        mock_get.side_effect = side_effect
-
-        grib = _grib()
-        grib.shortname_to_paramid("2t", origin="ecmf")
-
-        # Find the param search call (not the origin lookup)
-        param_calls = [c for c in mock_get.call_args_list if "param/" in str(c)]
-        assert len(param_calls) >= 1
-        param_url = param_calls[0][0][0]
-        assert "origin=98" in param_url, f"Expected origin to be resolved to numeric id 98, got URL: {param_url}"
-
-
-# ---------------------------------------------------------------------------
-# Local cache tests
-# ---------------------------------------------------------------------------
-
-# Minimal mock data modelled after parameters.json structure
-LOCAL_CACHE_DATA = [
-    {
-        "id": 1,
-        "name": "Stream function",
-        "shortname": "strf",
-        "unit_id": 1,
-        "encoding_ids": ["grib1", "grib2"],
-        "access_ids": ["dissemination"],
-        "published": True,
-        "pending": False,
-        "retired": False,
-    },
-    {
-        "id": 2,
-        "name": "Velocity potential",
-        "shortname": "vp",
-        "unit_id": 1,
-        "encoding_ids": ["grib1", "grib2"],
-        "access_ids": ["dissemination"],
-        "published": True,
-        "pending": False,
-        "retired": False,
-    },
-    {
-        "id": 10,
-        "name": "Wind speed",
-        "shortname": "ws",
-        "unit_id": 5,
-        "encoding_ids": ["grib1", "grib2"],
-        "access_ids": ["dissemination"],
-        "published": True,
-        "pending": False,
-        "retired": False,
-    },
-    {
-        "id": 31,
-        "name": "Sea ice area fraction",
-        "shortname": "ci",
-        "unit_id": 3,
-        "encoding_ids": ["grib1", "grib2"],
-        "access_ids": ["dissemination"],
-        "published": True,
-        "pending": False,
-        "retired": False,
-    },
-    {
-        "id": 34,
-        "name": "Sea surface temperature",
-        "shortname": "sst",
-        "unit_id": 2,
-        "encoding_ids": ["grib1", "grib2"],
-        "access_ids": ["dissemination"],
-        "published": True,
-        "pending": False,
-        "retired": False,
-    },
-    {
-        "id": 54,
-        "name": "Pressure",
-        "shortname": "pres",
-        "unit_id": 16,
-        "encoding_ids": ["grib1", "grib2"],
-        "access_ids": ["dissemination"],
-        "published": True,
-        "pending": False,
-        "retired": False,
-    },
-    {
-        "id": 59,
-        "name": "Convective available potential energy",
-        "shortname": "cape",
-        "unit_id": 17,
-        "encoding_ids": ["grib1", "grib2"],
-        "access_ids": [],
-        "published": True,
-        "pending": False,
-        "retired": False,
-    },
-    {
-        "id": 228059,
-        "name": "Convective available potential energy",
-        "shortname": "cape",
-        "unit_id": 17,
-        "encoding_ids": ["grib1", "grib2"],
-        "access_ids": [],
-        "published": True,
-        "pending": False,
-        "retired": False,
-    },
-]
-
-
-@pytest.fixture()
-def local_cache_file(tmp_path):
-    """Write LOCAL_CACHE_DATA to a temporary JSON file and return its path."""
-    cache_file = tmp_path / "parameters.json"
-    cache_file.write_text(json.dumps(LOCAL_CACHE_DATA))
-    return str(cache_file)
-
-
-@contextmanager
-def _patch_local_cache(grib_mod, cache_path):
-    """Temporarily set SETTINGS.paramdb.local_cache on the grib module and clear functools caches."""
-    old_value = grib_mod.SETTINGS.paramdb.local_cache
-    grib_mod.SETTINGS.paramdb.local_cache = Path(cache_path) if cache_path else None
-    # Clear functools.cache so results are not stale across tests
-    grib_mod._local_search_param.cache_clear()
-    grib_mod._get_local_db.cache_clear()
-    try:
-        yield
-    finally:
-        grib_mod.SETTINGS.paramdb.local_cache = old_value
-        grib_mod._local_search_param.cache_clear()
-        grib_mod._get_local_db.cache_clear()
-
-
-class TestLocalCacheSearch:
-    """Tests for _local_search_param and the SETTINGS.paramdb.local_cache routing in _search_param."""
-
-    def test_local_search_param_returns_single_match(self, local_cache_file):
-        """_local_search_param returns a one-element list for a known shortname."""
-        grib = _grib()
-        with _patch_local_cache(grib, local_cache_file):
-            results = grib._local_search_param("sst")
-            assert len(results) == 1
-            assert results[0]["shortname"] == "sst"
-            assert results[0]["id"] == 34
-
-    def test_local_search_param_raises_on_missing(self, local_cache_file):
-        """_local_search_param raises KeyError for an unknown shortname."""
-        grib = _grib()
-        with _patch_local_cache(grib, local_cache_file):
-            with pytest.raises(KeyError, match="not found in local cache"):
-                grib._local_search_param("nonexistent_param_xyz")
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_search_param_local_cache_no_network(self, mock_get, local_cache_file):
-        """Verify requests.get is never called when local_cache is configured."""
-        grib = _grib()
-        with _patch_local_cache(grib, local_cache_file):
-            result = grib._search_param("ws")
-            mock_get.assert_not_called()
-            assert result["shortname"] == "ws"
-            assert result["id"] == 10
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_shortname_to_paramid_via_local_cache(self, mock_get, local_cache_file):
-        """End-to-end: shortname_to_paramid works with the local cache."""
-        grib = _grib()
-        with _patch_local_cache(grib, local_cache_file):
-            assert grib.shortname_to_paramid("ci") == 31
-            assert grib.shortname_to_paramid("sst") == 34
-            assert grib.shortname_to_paramid("pres") == 54
-            mock_get.assert_not_called()
-
-    @patch("anemoi.utils.grib.requests.get")
-    def test_paramid_to_shortname_via_local_cache(self, mock_get, local_cache_file):
-        """_search_param finds entries via local cache for reverse lookups."""
-        grib = _grib()
-        with _patch_local_cache(grib, local_cache_file):
-            result = grib._search_param("sst")
-            assert result["shortname"] == "sst"
-            mock_get.assert_not_called()
-
-    @patch("anemoi.utils.grib.warnings.warn")
-    def test_local_cache_filters_ignored_with_warning(self, mock_warning, local_cache_file):
-        """When local_cache is set, passing filters emits a warning."""
-        grib = _grib()
-        with _patch_local_cache(grib, local_cache_file):
-            result = grib._search_param("sst", origin=98)
-            mock_warning.assert_called()
-            warning_msg = mock_warning.call_args[0][0]
-            assert "ignored" in warning_msg.lower() or "Filters" in warning_msg
-            assert result["id"] == 34
-
-    def test_local_search_multiple_params(self, local_cache_file):
-        """Verify several known parameters from the mock cache are found."""
-        grib = _grib()
-        with _patch_local_cache(grib, local_cache_file):
-            expected = {
-                "strf": 1,
-                "vp": 2,
-                "ws": 10,
-            }
-            for shortname, expected_id in expected.items():
-                results = grib._local_search_param(shortname)
-                assert len(results) == 1
-                assert (
-                    results[0]["id"] == expected_id
-                ), f"Expected {shortname} -> id={expected_id}, got {results[0]['id']}"
+    def test_accepts_paramid(self, grib):
+        assert grib.must_be_positive(228) is True  # tp, units: m
+        assert grib.must_be_positive(167) is False  # 2t, units: K

--- a/tests/test_grib.py
+++ b/tests/test_grib.py
@@ -41,6 +41,18 @@ def _offline_paramdb():
     return ParamDB(mode="offline")
 
 
+def _install_paramdb(monkeypatch, db):
+    """Install *db* as the active ParamDB and neutralise settings-level filters.
+
+    Returns the patched ``anemoi.utils.grib`` module.
+    """
+    import anemoi.utils.grib as grib_mod
+
+    monkeypatch.setattr(grib_mod, "get_paramdb", lambda: db)
+    monkeypatch.setattr(grib_mod.PARAMDB_SETTINGS, "default_filters", None, raising=False)
+    return grib_mod
+
+
 @pytest.fixture(params=["local", "bundled"])
 def grib(request, monkeypatch, _local_paramdb, _offline_paramdb):
     """Swap anemoi.utils.grib.PARAMDB to the requested backend.
@@ -48,12 +60,14 @@ def grib(request, monkeypatch, _local_paramdb, _offline_paramdb):
     'local' reuses a session-scoped ParamDB pointing at our test YAML.
     'bundled' constructs one from pymetkit's default YAML lookup (which may
     not exist, in which case the test xfails on FileNotFoundError).
-    """
-    import anemoi.utils.grib as grib_mod
 
+    Tests can restrict to a single backend via indirect parametrisation, e.g.::
+
+        @pytest.mark.parametrize("grib", ["local"], indirect=True)
+        class TestOnlyLocal: ...
+    """
     db = _local_paramdb if request.param == "local" else _offline_paramdb
-    monkeypatch.setattr(grib_mod, "PARAMDB", db)
-    return grib_mod
+    return _install_paramdb(monkeypatch, db)
 
 
 # ---------------------------------------------------------------------------
@@ -174,3 +188,97 @@ class TestMustBePositive:
     def test_accepts_paramid(self, grib):
         assert grib.must_be_positive(228) is True  # tp, units: m
         assert grib.must_be_positive(167) is False  # 2t, units: K
+
+
+# ---------------------------------------------------------------------------
+# Shortname collision handling
+# ---------------------------------------------------------------------------
+
+
+class TestShortnameCollisions:
+    """The fixture YAML contains a colliding shortname 't' (paramids 130 and 500014).
+
+    Restricted to the ``local`` backend: the bundled pymetkit DB does not
+    contain the same candidate set for 't' (e.g. no ``origin=7`` variant).
+
+    - No filter and no default_filters -> WARN and fall back to ``context={}``
+      (returns 130 in the fixture).
+    - Explicit disambiguating filter -> no warning, correct paramid.
+    - Settings-level ``default_filters`` -> used when no explicit filter passed.
+    """
+
+    pytestmark = pytest.mark.parametrize("grib", ["local"], indirect=True)
+
+    COLLIDING_SHORTNAME = "t"
+    DEFAULT_CONTEXT_PARAMID = 130  # what ``context={}`` resolves to
+    ALT_ORIGIN = 7
+    ALT_ORIGIN_PARAMID = 500014
+
+    def test_collision_warns_and_returns_default(self, grib, caplog):
+        import logging
+
+        # Ensure no default filters interfere.
+        grib.PARAMDB_SETTINGS.default_filters = None
+
+        with caplog.at_level(logging.WARNING, logger="anemoi.utils.grib"):
+            result = grib.shortname_to_paramid(self.COLLIDING_SHORTNAME)
+
+        assert result == self.DEFAULT_CONTEXT_PARAMID
+        assert any(
+            "collisions" in rec.message and self.COLLIDING_SHORTNAME in rec.message for rec in caplog.records
+        ), "expected a warning listing candidates for the colliding shortname"
+
+    def test_explicit_filter_disambiguates_without_warning(self, grib, caplog):
+        import logging
+
+        grib.PARAMDB_SETTINGS.default_filters = None
+
+        with caplog.at_level(logging.WARNING, logger="anemoi.utils.grib"):
+            result = grib.shortname_to_paramid(self.COLLIDING_SHORTNAME, origin=self.ALT_ORIGIN)
+
+        assert result == self.ALT_ORIGIN_PARAMID
+        assert not any("collisions" in rec.message for rec in caplog.records)
+
+    def test_default_filters_from_settings_used(self, grib, caplog, monkeypatch):
+        import logging
+
+        monkeypatch.setattr(
+            grib.PARAMDB_SETTINGS,
+            "default_filters",
+            {"origin": self.ALT_ORIGIN},
+            raising=False,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="anemoi.utils.grib"):
+            result = grib.shortname_to_paramid(self.COLLIDING_SHORTNAME)
+
+        assert result == self.ALT_ORIGIN_PARAMID
+        assert not any("collisions" in rec.message for rec in caplog.records)
+
+    def test_shipped_default_disambiguates_local_fixture(self, grib, caplog):
+        """The shipped defaults.toml sets ``access = "dissemination"``.
+
+        Verify it silently disambiguates our fixture's 't' collision without
+        needing an explicit filter at the call site.
+        """
+        import logging
+
+        from anemoi.utils.settings_schema.paramdb import ParamDBConfig
+
+        grib.PARAMDB_SETTINGS.default_filters = ParamDBConfig().default_filters
+        assert grib.PARAMDB_SETTINGS.default_filters == {"access": "dissemination"}
+
+        with caplog.at_level(logging.WARNING, logger="anemoi.utils.grib"):
+            result = grib.shortname_to_paramid(self.COLLIDING_SHORTNAME)
+
+        assert result == self.DEFAULT_CONTEXT_PARAMID
+        assert not any("collisions" in rec.message for rec in caplog.records)
+
+    def test_non_colliding_shortname_no_warning(self, grib, caplog):
+        import logging
+
+        grib.PARAMDB_SETTINGS.default_filters = None
+        with caplog.at_level(logging.WARNING, logger="anemoi.utils.grib"):
+            grib.shortname_to_paramid("2t")
+
+        assert not any("collisions" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Description
Switch to use `pymetkit`'s paramDB

Removes our custom retrieval from `codes.ecmwf.int` and enables more consistent use of a local db, paving the way for other organisations to provide their own mappings.

> [!NOTE]
> Requires: https://github.com/ecmwf/metkit/pull/185

API is unchanged, with existing functions aliasing, `pymetkit`'s functions directly.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-utils start -->
----
📚 Documentation preview 📚: https://anemoi-utils--314.org.readthedocs.build/en/314/

<!-- readthedocs-preview anemoi-utils end -->