### PR TITLE
feat: option to allow extra settings in anemoi config

### DIFF
--- a/src/anemoi/utils/settings.py
+++ b/src/anemoi/utils/settings.py
@@ -92,6 +92,9 @@ def _ensure_secure_file(path: Path) -> None:
 
 
 _WILDCARD = "*"
+# Top-level boolean key that can be set in the secrets file to opt out of
+# dropping non-secret keys found there. Accepts hyphen or underscore spelling.
+_KEEP_EXTRAS_KEYS = ("keep-extra-settings", "keep_extra_settings")
 # A SecretTree is a nested dict where leaves are True (SecretStr) and inner
 # nodes are sub-trees keyed by underscore-normalised field name. The special
 # key "*" represents typed extras (`__pydantic_extra__: dict[str, Model]`).
@@ -159,6 +162,22 @@ def _flatten_tree(d: DataTree, prefix: str = "") -> list[str]:
     return out
 
 
+def _deep_merge(base: DataTree, extra: DataTree) -> DataTree:
+    """Recursively merge *extra* into *base*, returning a new dict.
+
+    Values from *base* take precedence over *extra* on leaf conflicts; nested
+    dicts are merged key by key. Used to fold non-secret keys back into the
+    secret payload without clobbering already-resolved secret leaves.
+    """
+    out: DataTree = dict(base)
+    for k, v in extra.items():
+        if k in out and isinstance(out[k], dict) and isinstance(v, dict):
+            out[k] = _deep_merge(out[k], v)
+        elif k not in out:
+            out[k] = v
+    return out
+
+
 def _split_secrets(data: DataTree, tree: SecretTree) -> tuple[DataTree, DataTree]:
     """Partition *data* into (secret_part, non_secret_part) using *tree*."""
     secret: DataTree = {}
@@ -218,14 +237,23 @@ class AnemoiSecretsSource(PydanticBaseSettingsSource):
         data: dict[str, Any] = {**self._yaml_source(), **self._toml_source()}
         if not data:
             return {}
+        keep_extras = False
+        for key in _KEEP_EXTRAS_KEYS:
+            if key in data:
+                keep_extras = bool(data.pop(key))
         secret, rest = _split_secrets(data, self._secret_tree)
+        result = convert_to_secret(secret) if secret else {}
         if rest:
-            logger.warning(
-                "Ignoring non-secret keys in secrets file(s): %s. Move these to %s.",
-                sorted(_flatten_tree(rest)),
-                self._toml_path.with_name(self._toml_path.name.replace(".secrets", "")),
-            )
-        return convert_to_secret(secret) if secret else {}
+            if keep_extras:
+                result = _deep_merge(result, rest)
+            else:
+                logger.warning(
+                    "Ignoring non-secret keys in secrets file(s): %s. Move these to %s, "
+                    "or set `keep_extra_settings = true` in the secrets file to keep them.",
+                    sorted(_flatten_tree(rest)),
+                    self._toml_path.with_name(self._toml_path.name.replace(".secrets", "")),
+                )
+        return result
 
 
 class AnemoiNonSecretsSource(PydanticBaseSettingsSource):

--- a/src/anemoi/utils/settings_schema/settings.defaults.toml
+++ b/src/anemoi/utils/settings_schema/settings.defaults.toml
@@ -15,6 +15,13 @@
 #
 #     ~/.config/anemoi/settings.secrets.toml     (chmod 600)
 #
+# By default, only secret-typed keys are read from the secrets file; any
+# non-secret keys found there are ignored (with a warning) to encourage
+# separation of concerns. To keep them instead, add this top-level line to
+# the secrets file:
+#
+#     keep_extra_settings = true
+#
 # Environment variable overrides
 # --------------------------------
 # Settings use pydantic-settings with the prefix ANEMOI_SETTINGS_.


### PR DESCRIPTION
## Description
The recent changes in anemoi-utils hides some of the keys that I have in my ~/.config/anemoi/settings.secrets.toml

- [object-storage] 
    endpoint_url = ''
I consider this as secret, but anemoi now insist that I write them in the non secret place.
I should choose what is a secret, not the software.

- Custom secrets are not accessible.
I put other secrets related to anemoi, they were hidden (with a warning)


## What problem does this change solve?
I can put config keys where I want in  ~/.config/anemoi/settings*.toml


##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
