### PR TITLE
feat: support data in azure blob storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ trace.txt
 *.prof
 prof/
 *.gz
+
+# Azure tests
+__blobstorage__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "rich",
   "tqdm",
 ]
-optional-dependencies.all = [ "anemoi-utils[grib,mlflow,provenance,s3,text]" ]
+optional-dependencies.all = [ "anemoi-utils[grib,mlflow,provenance,remote,text]" ]
 optional-dependencies.dev = [ "anemoi-utils[all,docs,tests]" ]
 optional-dependencies.docs = [
   "anemoi-utils[all]",
@@ -63,9 +63,8 @@ optional-dependencies.docs = [
 optional-dependencies.grib = [ "requests" ]
 optional-dependencies.mlflow = [ "mlflow-skinny>=2.11.1", "requests" ]
 optional-dependencies.provenance = [ "gitpython", "nvsmi" ]
-optional-dependencies.s3 = [
-  "obstore",
-]
+optional-dependencies.remote = [ "obstore" ]
+optional-dependencies.s3 = [ "anemoi-utils[remote]" ]  # deprecated, use "remote"
 optional-dependencies.tests = [ "anemoi-utils[mlflow,provenance]", "pytest", "pytest-mock>=3" ]
 optional-dependencies.text = [ "termcolor", "wcwidth" ]
 urls.Documentation = "https://anemoi-utils.readthedocs.io/"
@@ -80,6 +79,10 @@ package-data."anemoi.utils.settings_schema" = [ "*.toml" ]
 
 [tool.setuptools_scm]
 version_file = "src/anemoi/utils/_version.py"
+
+[tool.ruff]
+line-length = 120
+extend-exclude = ["docs/**/*_.py"]
 
 [tool.mypy]
 mypy_path = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,10 +82,8 @@ version_file = "src/anemoi/utils/_version.py"
 
 [tool.ruff]
 line-length = 120
-extend-exclude = ["docs/**/*_.py"]
-
-[tool.ruff.lint.isort]
-force-single-line = true
+extend-exclude = [ "docs/**/*_.py" ]
+lint.isort.force-single-line = true
 
 [tool.mypy]
 mypy_path = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ version_file = "src/anemoi/utils/_version.py"
 line-length = 120
 extend-exclude = ["docs/**/*_.py"]
 
+[tool.ruff.lint.isort]
+force-single-line = true
+
 [tool.mypy]
 mypy_path = "src"
 exclude = [

--- a/src/anemoi/utils/remote/__init__.py
+++ b/src/anemoi/utils/remote/__init__.py
@@ -604,12 +604,15 @@ def _find_transfer_class(source: str, target: str) -> type:
     from_s3 = source.startswith("s3://")
     into_s3 = target.startswith("s3://")
 
-    from_local = not from_ssh and not from_s3
-    into_local = not into_ssh and not into_s3
+    from_az = source.startswith("abfs://")
+    into_az = target.startswith("abfs://")
+
+    from_local = not any([from_ssh, from_s3, from_az])
+    into_local = not any([into_ssh, into_s3, into_az])
 
     # check that exactly one source type and one target type is specified
-    assert sum([into_ssh, into_local, into_s3]) == 1, (into_ssh, into_local, into_s3)
-    assert sum([from_ssh, from_local, from_s3]) == 1, (from_ssh, from_local, from_s3)
+    assert sum([into_ssh, into_local, into_s3, into_az]) == 1, (into_ssh, into_local, into_s3, into_az)
+    assert sum([from_ssh, from_local, from_s3, from_az]) == 1, (from_ssh, from_local, from_s3, from_az)
 
     if from_local and into_ssh:  # local -> ssh
         from .ssh import RsyncUpload
@@ -621,10 +624,20 @@ def _find_transfer_class(source: str, target: str) -> type:
 
         return S3Download
 
+    if from_az and into_local:  # local <- Azure
+        from .az import AzureDownload
+
+        return AzureDownload
+
     if from_local and into_s3:  # local -> S3
         from .s3 import S3Upload
 
         return S3Upload
+
+    if from_local and into_az:  # local -> Azure
+        from .az import AzureUpload
+
+        return AzureUpload
 
     raise TransferMethodNotImplementedError(f"Transfer from {source} to {target} is not implemented")
 
@@ -638,16 +651,17 @@ def transfer(
     Parameters
     ----------
     source : str
-        A path to a local file or folder or a URL to a file or a folder on S3.
-        The url should start with 's3://'.
+        A path to a local file or folder or a URL to a file or a folder on S3 or Azure Blob Storage.
+        The url should start with 's3://' or 'abfs://', respectively.
     target : str
-        A path to a local file or folder or a URL to a file or a folder on S3 or a remote folder.
-        The url should start with 's3://' or 'ssh://'.
+        A path to a local file or folder or a URL to a file or a folder on S3, Azure Blob Storage, or a remote folder.
+        The url should start with 's3://', 'abfs://', or 'ssh://', respectively.
     overwrite : bool, optional
         If the data is already on in the target location it will be overwritten.
         By default False
     resume : bool, optional
-        If the data is already on S3 it will not be uploaded, unless the remote file has a different size
+        If the data is already on S3 or Azure Blob Storage it will not be uploaded, unless the remote file has a
+        different size.
         Ignored if the target is an SSH remote folder (ssh://).
         By default False
     verbosity : int, optional
@@ -660,7 +674,8 @@ def transfer(
     temporary_target : bool, optional
         Experimental feature
         If True and if the target location supports it, the data will be uploaded to a temporary location
-        then renamed to the final location. Supported by SSH and local targets, not supported by S3.
+        then renamed to the final location. Supported by SSH and local targets, not supported by S3 or Azure Blob
+        Storage.
         By default False.
 
     Returns

--- a/src/anemoi/utils/remote/az.py
+++ b/src/anemoi/utils/remote/az.py
@@ -1,0 +1,947 @@
+# (C) Copyright 2024-2026 Anemoi contributors.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Management of objects in Azure Blob Storage.
+
+Provides functions to upload, download, list, and delete files and folders, including hierarchical namespace (Azure Data
+Lake Storage Gen 2).
+
+Only `abfs://` scheme URLs are accepted in one of two shapes, including **optional** query strings for SAS tokens (e.g.
+suffixed `?sv=...`):
+
+- `abfs://<container>/<path>`: account name comes from settings or environment variables
+- `abfs://<container>@<account>.dfs.core.windows.net/<path>?`: account name in the URL (`.blob.core.windows.net` also
+accepted)
+
+Credentials can be supplied via `~/.config/anemoi/settings.toml` (or `settings.secrets.toml`) under the `object-storage`
+section:
+
+```toml
+    [object-storage]
+    endpoint_url = "..."  # for Azure, only needed for sovereign clouds / Azurite
+    account_name = "..."  # storage account name
+    account_key = "..."  # storage account key
+    sas_token = "?sv=..."  # SAS token instead of an account key
+    skip_signature = true  # for public / anonymous containers
+
+    # container-keyed overrides, if source and destination are in different accounts or have different credentials
+    ["object-storage.training-data"]
+    account_name = "..."
+    sas_token = "?sv=..."
+```
+
+Alternatively, `obstore` attempts to read standard Azure environment variables directly if no credentials are configured
+as above. For a list of supported environment variables, see
+[`obstore` documentation](https://developmentseed.org/obstore/latest/api/store/azure/#obstore.store.AzureConfig).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import os
+import re
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Literal
+from typing import overload
+
+import obstore
+import tqdm  # type: ignore[import-untyped]
+
+from ..humanize import bytes_to_human
+from ..settings import SETTINGS
+from ..settings_schema.object_storage import AZURE_CLIENT_FIELDS
+from ..settings_schema.object_storage import ObjectStorageBucketConfig
+from . import BaseDownload
+from . import BaseUpload
+from . import Loader
+from . import transfer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from collections.abc import Sequence
+
+    # obstore.ObjectMeta not importable at runtime, must be within TYPE_CHECKING
+    from obstore import ObjectMeta
+
+LOG = logging.getLogger(__name__)
+
+# Avoids creating a new connection pool on every Azure read during training.
+CLIENT_CACHE: dict[str, obstore.store.ObjectStore] = {}
+CLIENT_LOCK = threading.Lock()
+
+_ABFS_SCHEME = "abfs://"
+_ABFS_HOST_RE = re.compile(
+    r"^(?P<container>[^@/]+)@(?P<account>[^./]+)\.(?:blob|dfs)\.[^/]+$",
+    re.IGNORECASE,
+)
+
+
+def _assert_azure_url(url: str) -> None:
+    """Assert that a URL is a supported Azure Blob Storage URL.
+
+    Parameters
+    ----------
+    url : str
+        Candidate URL.
+
+    Raises
+    ------
+    ValueError
+        If the URL does not begin with abfs://.
+
+    """
+    if not url.lower().startswith(_ABFS_SCHEME):
+        msg = f"Invalid Azure URL: {url} (expected '{_ABFS_SCHEME}')"
+        raise ValueError(msg)
+
+
+class AzureObject:
+    """Parsed representation of an Azure Blob Storage URL."""
+
+    def __init__(self, url: str) -> None:
+        """Parse an Azure Blob Storage URL into container, account, path and optional SAS query.
+
+        Parameters
+        ----------
+        url : str
+            Azure Blob Storage URL beginning with abfs://. Both abfs://<container>/<path> and
+            abfs://<container>@<account>.<blob|dfs>.core.windows.net/<path> forms are accepted, with an optional ?<sas>
+            query suffix.
+
+        Raises
+        ------
+        ValueError
+            If the URL does not begin with abfs://, or if the container segment is empty.
+
+        """
+        self.url = url
+        base, _, query = url.partition("?")
+        self.query = query  # may contain SAS token
+        _assert_azure_url(base)
+        rest = base[len(_ABFS_SCHEME) :]
+        host_part, _, path = rest.partition("/")
+
+        host_match = _ABFS_HOST_RE.match(host_part)
+        if host_match:
+            self.account = host_match.group("account")
+            self.container = host_match.group("container")
+        else:
+            self.account = None
+            self.container = host_part
+        self.path = path
+
+        if not self.container:
+            msg = f"Missing container in Azure URL: {url}"
+            raise ValueError(msg)
+
+        self.dirname = f"{_ABFS_SCHEME}{self.container}"
+        # distinguish same-container-different-account for CLIENT_CACHE
+        self.cache_key = f"{self.account or '_'}::{self.container}"
+
+
+def _azure_object(url_or_object: str | AzureObject) -> AzureObject:
+    """Coerce a URL or existing AzureObject into an AzureObject.
+
+    Parameters
+    ----------
+    url_or_object : str | AzureObject
+        Azure Blob Storage URL or a pre-parsed AzureObject.
+
+    Returns
+    -------
+    AzureObject
+        Parsed representation of the given URL, or the input unchanged if already parsed.
+
+    Raises
+    ------
+    TypeError
+        If url_or_object is neither a string nor an AzureObject.
+
+    """
+    if isinstance(url_or_object, AzureObject):
+        return url_or_object
+    if isinstance(url_or_object, str):
+        return AzureObject(url_or_object)
+    msg = f"Invalid type for Azure object: {type(url_or_object)}"
+    raise TypeError(msg)
+
+
+def _azure_options(obj: str | AzureObject) -> ObjectStorageBucketConfig:
+    """Resolve credentials and endpoint for the container referenced by obj.
+
+    Container-keyed overrides under [object-storage.<pattern>] in settings take precedence over the top-level
+    [object-storage] block, the pattern is matched against the container name using fnmatch.
+
+    Parameters
+    ----------
+    obj : str | AzureObject
+        Azure Blob Storage URL or a pre-parsed AzureObject.
+
+    Returns
+    -------
+    ObjectStorageBucketConfig
+        Resolved credentials and endpoint for the container.
+
+    Raises
+    ------
+    ValueError
+        If more than one container-keyed override matches obj.container.
+
+    """
+    obj = _azure_object(obj)
+    object_storage_cfg = SETTINGS.object_storage
+    # per-container overrides in __pydantic_extra__, fixed model fields are the globals
+    container_overrides = object_storage_cfg.__pydantic_extra__ or {}
+
+    candidate: ObjectStorageBucketConfig | None = None
+    candidate_key: str | None = None
+    for key in container_overrides:
+        if fnmatch.fnmatch(obj.container, key):
+            if candidate is not None:
+                msg = f"Multiple object storage configurations match {obj.container}: {candidate_key} and {key}"
+                raise ValueError(msg)
+            candidate = container_overrides[key]
+            candidate_key = key
+
+    if candidate:
+        config = candidate.model_dump(by_alias=False, exclude_none=True)
+    else:
+        LOG.debug(
+            "No specific object storage configuration found for container %s, using global settings",
+            obj.container,
+        )
+        config = object_storage_cfg.model_dump(by_alias=False, exclude_none=True, include=set(AZURE_CLIENT_FIELDS))
+
+    resolved_object_config = ObjectStorageBucketConfig(**config)
+    LOG.info("Using Azure options: %s", resolved_object_config)
+    return resolved_object_config
+
+
+def azure_client(obj: str | AzureObject) -> obstore.store.ObjectStore:
+    """Return a cached obstore client for the container referenced by obj.
+
+    The client is keyed by account and container so that requests to different accounts sharing a container name do not
+    collide in the cache. Credential precedence, highest to lowest:
+
+    - SAS token in the URL query
+    - SAS token in settings
+    - Account key in settings
+    - Anonymous access (skip_signature).
+
+    If none are set, obstore falls back to the standard AZURE_STORAGE_* environment variables.
+
+    Parameters
+    ----------
+    obj : str | AzureObject
+        Azure Blob Storage URL or a pre-parsed AzureObject.
+
+    Returns
+    -------
+    obstore.store.ObjectStore
+        Ready-to-use client for the account and container referenced by obj.
+
+    """
+    obj = _azure_object(obj)
+
+    with CLIENT_LOCK:
+        if obj.cache_key in CLIENT_CACHE:
+            return CLIENT_CACHE[obj.cache_key]
+
+        options = _azure_options(obj)
+        LOG.debug("Using Azure options: %s", options)
+
+        kwargs: dict[str, Any] = {}
+
+        # account name from URL first, then settings
+        if obj.account is not None:
+            kwargs["account_name"] = obj.account
+        elif options.account_name is not None:
+            kwargs["account_name"] = options.account_name.get_secret_value()
+        # if still unset, obstore attempts AZURE_STORAGE_ACCOUNT_NAME env var
+
+        # endpoint override (sovereign / govt clouds, Azurite, etc.)
+        if options.endpoint_url is not None:
+            kwargs["endpoint"] = options.endpoint_url
+
+        # credential precedence: SAS in URL > SAS in settings > account key > anonymous
+        # if unset, obstore attempts AZURE_STORAGE_* env vars
+        if obj.query:
+            kwargs["sas_key"] = obj.query
+        elif options.sas_token is not None:
+            kwargs["sas_key"] = options.sas_token.get_secret_value()
+        elif options.account_key is not None:
+            kwargs["account_key"] = options.account_key.get_secret_value()
+        elif options.skip_signature:
+            kwargs["skip_signature"] = True
+
+        CLIENT_CACHE[obj.cache_key] = obstore.store.from_url(obj.dirname, **kwargs)
+        return CLIENT_CACHE[obj.cache_key]
+
+
+@overload
+def _list_objects(target: str | AzureObject, *, batch: Literal[True]) -> Iterable[Sequence[ObjectMeta]]: ...
+
+
+@overload
+def _list_objects(target: str | AzureObject, *, batch: Literal[False] = False) -> Iterable[ObjectMeta]: ...
+
+
+def _list_objects(
+    target: str | AzureObject,
+    *,
+    batch: bool = False,
+) -> Iterable[Sequence[ObjectMeta]] | Iterable[ObjectMeta]:
+    """List blobs under the URL prefix.
+
+    Parameters
+    ----------
+    target : str | AzureObject
+        Azure Blob Storage URL or a pre-parsed AzureObject used as a prefix. Only blobs whose paths begin with the URL's
+        path segment are yielded.
+    batch : bool, default = False
+        If True, yield one page of blob metadata at a time as returned by obstore, if False, yield one blob at a time.
+
+    Yields
+    ------
+    Sequence[ObjectMeta] | ObjectMeta
+        One blob (batch=False) or one page of blobs (batch=True) per iteration.
+
+    """
+    obj = _azure_object(target)
+    client = azure_client(obj)
+    path = obj.path.strip("/")
+    prefix = f"{path}/" if path else ""
+    for files in obstore.list(client, prefix, chunk_size=1024):
+        if batch:
+            yield files
+        else:
+            yield from files
+
+
+def list_folder(folder: str) -> Iterable[ObjectMeta]:
+    """List blobs under the URL prefix.
+
+    Parameters
+    ----------
+    folder : str
+        Azure Blob Storage URL used as a prefix.
+
+    Returns
+    -------
+    Iterable[ObjectMeta]
+        One item per blob under the prefix.
+
+    """
+    return _list_objects(folder)
+
+
+def delete_folder(target: str) -> None:
+    """Delete all blobs under the URL prefix.
+
+    Parameters
+    ----------
+    target : str
+        Azure Blob Storage URL used as a prefix.
+
+    """
+    obj = _azure_object(target)
+    client = azure_client(obj)
+    total = 0
+    for batch in _list_objects(obj, batch=True):
+        paths = [o["path"] for o in batch]
+        LOG.info("Deleting %s objects from %s", len(batch), target)
+        obstore.delete(client, paths)
+        total += len(batch)
+        LOG.info("Deleted %s objects (total=%s)", len(batch), total)
+
+
+def delete_file(target: str) -> None:
+    """Delete a single blob.
+
+    If no blob exists at the URL, a warning is logged and no error is raised.
+
+    Parameters
+    ----------
+    target : str
+        Azure Blob Storage URL for the blob to delete.
+
+    """
+    obj = _azure_object(target)
+    client = azure_client(obj)
+    if not object_exists(obj):
+        LOG.warning("%s does not exist. Did you mean to delete a folder? Add a trailing '/'", target)
+        return
+    LOG.info("Deleting %s", target)
+    obstore.delete(client, obj.path)
+    LOG.info("%s is deleted", target)
+
+
+def delete(target: str) -> None:
+    """Delete a single blob or all blobs under a prefix.
+
+    Dispatches to delete_folder if target ends with '/', otherwise delete_file.
+
+    Parameters
+    ----------
+    target : str
+        Azure Blob Storage URL. Treated as a prefix if it ends with '/', otherwise as a single blob.
+
+    """
+    if target.endswith("/"):
+        delete_folder(target)
+    else:
+        delete_file(target)
+
+
+def object_info(target: str | AzureObject) -> ObjectMeta:
+    """Fetch metadata for a single blob.
+
+    Parameters
+    ----------
+    target : str | AzureObject
+        Azure Blob Storage URL or a pre-parsed AzureObject.
+
+    Returns
+    -------
+    ObjectMeta
+        Metadata for the blob, including size, path, and last-modified time.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no blob exists at the URL.
+
+    """
+    obj = _azure_object(target)
+    client = azure_client(obj)
+    return client.head(obj.path)
+
+
+def object_exists(target: str | AzureObject) -> bool:
+    """Check whether a blob exists at the URL.
+
+    Parameters
+    ----------
+    target : str | AzureObject
+        Azure Blob Storage URL or a pre-parsed AzureObject.
+
+    Returns
+    -------
+    bool
+        True if the blob exists, False otherwise.
+
+    """
+    obj = _azure_object(target)
+    client = azure_client(obj)
+    try:
+        client.head(obj.path)
+    except FileNotFoundError:
+        return False
+    else:
+        return True
+
+
+def get_object(target: str) -> obstore.Bytes:
+    """Fetch a blob and return its contents.
+
+    Parameters
+    ----------
+    target : str
+        Azure Blob Storage URL.
+
+    Returns
+    -------
+    obstore.Bytes
+        The blob's contents.
+
+    """
+    obj = _azure_object(target)
+    client = azure_client(obj)
+    return client.get(obj.path).bytes()
+
+
+def get_objects_parallel(targets: list[str]) -> list[obstore.Bytes]:
+    """Fetch multiple blobs concurrently.
+
+    Each fetch is retried up to three times on errors other than FileNotFoundError, which is raised immediately without
+    retry.
+
+    Parameters
+    ----------
+    targets : list[str]
+        Azure Blob Storage URLs to fetch.
+
+    Returns
+    -------
+    list[obstore.Bytes]
+        Blob contents, in the same order as targets.
+
+    Raises
+    ------
+    FileNotFoundError
+        If any blob does not exist.
+    OSError
+        If any fetch fails three times consecutively for reasons other than the blob being missing.
+
+    """
+
+    def _fetch(target: str) -> obstore.Bytes:
+        obj = _azure_object(target)
+        client = azure_client(obj)
+        last_exc = None
+        for attempt in range(3):
+            try:
+                return client.get(obj.path).bytes()
+            except FileNotFoundError:
+                raise
+            except Exception as e:
+                last_exc = e
+                LOG.exception("Fetch attempt %s/3 failed for %s.", attempt + 1, target)
+        msg = f"Failed to fetch {target} after 3 attempts: {last_exc}"
+        raise OSError(msg)
+
+    with ThreadPoolExecutor(max_workers=len(targets)) as ex:
+        return list(ex.map(_fetch, targets))
+
+
+def upload(source: str, target: str, *args: bool | int, **kwargs: bool | int) -> Loader:
+    """Upload a local file or directory to Azure Blob Storage via transfer.
+
+    Parameters
+    ----------
+    source : str
+        Local file or directory path.
+    target : str
+        Azure Blob Storage URL for the destination. Ends with '/' for a directory upload.
+    *args : bool | int
+        Additional positional arguments passed through to transfer.
+    **kwargs : bool | int
+        Additional keyword arguments passed through to transfer.
+
+    Returns
+    -------
+    Loader
+        Loader that performs and reports on the transfer when iterated.
+
+    """
+    _assert_azure_url(target)
+    return transfer(source, target, *args, **kwargs)
+
+
+def upload_file(source: str, target: str, overwrite: bool, resume: bool, verbosity: int) -> int:
+    """Upload a single local file to Azure Blob Storage.
+
+    Parameters
+    ----------
+    source : str
+        Local file path to upload.
+    target : str
+        Azure Blob Storage URL for the destination blob.
+    overwrite : bool
+        If True, replace any existing blob at the destination.
+    resume : bool
+        If True, skip the upload when a blob of the expected size already exists at the destination.
+    verbosity : int
+        Verbosity level: 0 is silent, higher values show more progress.
+
+    Returns
+    -------
+    int
+        Number of bytes transferred.
+
+    Raises
+    ------
+    ValueError
+        If a blob already exists at the destination and neither overwrite nor resume is set.
+
+    """
+    obj = _azure_object(target)
+    client = azure_client(obj)
+    size = Path(source).stat().st_size
+    if verbosity > 0:
+        LOG.info("Upload %s to %s (%s)", source, target, bytes_to_human(size))
+
+    try:
+        remote_size = object_info(obj)["size"]
+    except FileNotFoundError:
+        remote_size = None
+
+    if remote_size is not None:
+        if remote_size != size and overwrite:
+            LOG.warning(
+                "%s already exists, but with different size, re-uploading (remote=%s, local=%s)",
+                target,
+                remote_size,
+                size,
+            )
+        elif resume:
+            return size
+
+    if remote_size is not None and not overwrite and not resume:
+        msg = f"{target} already exists, use 'overwrite' to replace or 'resume' to skip"
+        raise ValueError(msg)
+
+    chunk_size = 1024 * 1024 * 10
+    total = size
+    with (
+        tqdm.tqdm(
+            desc=obj.path,
+            total=size,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
+            leave=verbosity >= 2,
+            delay=0 if verbosity > 0 else 10,
+        ) as pbar,
+        Path(source).open("rb") as f,
+        closing(obstore.open_writer(client, obj.path, buffer_size=chunk_size)) as g,
+    ):
+        while total > 0:
+            chunk = f.read(min(chunk_size, total))
+            g.write(chunk)
+            pbar.update(len(chunk))
+            total -= len(chunk)
+    return size
+
+
+class AzureUpload(BaseUpload):
+    """Transfer implementation for uploading local files and directories to Azure Blob Storage."""
+
+    def get_temporary_target(self, target: str, _: str) -> str:  # type: ignore[override]
+        """Return the final target unchanged.
+
+        Azure Blob Storage uploads write directly to the destination.
+
+        Parameters
+        ----------
+        target : str
+            Azure Blob Storage URL for the destination.
+        _ : str
+            Ignored, kept for signature compatibility with the base class.
+
+        Returns
+        -------
+        str
+            The target URL, unchanged.
+
+        """
+        return target
+
+    def rename_target(self, target: str, temporary_target: str) -> None:
+        """No-op, Azure Blob Storage uploads write directly to the destination.
+
+        Parameters
+        ----------
+        target : str
+            Final Azure Blob Storage URL. Unused.
+        temporary_target : str
+            Temporary Azure Blob Storage URL. Unused.
+
+        """
+
+    def delete_target(self, target: str) -> None:
+        """No-op, Azure Blob Storage uploads write directly to the destination.
+
+        Parameters
+        ----------
+        target : str
+            Azure Blob Storage URL. Unused.
+
+        """
+
+    def _transfer_file(
+        self,
+        source: str,
+        target: str,
+        overwrite: bool,
+        resume: bool,
+        verbosity: int,
+        **_: object,
+    ) -> int:
+        """Upload a single local file to Azure Blob Storage.
+
+        Parameters
+        ----------
+        source : str
+            Local file path to upload.
+        target : str
+            Azure Blob Storage URL for the destination blob.
+        overwrite : bool
+            If True, replace any existing blob at the destination.
+        resume : bool
+            If True, skip the upload when a blob of the expected size already exists at the destination.
+        verbosity : int
+            Verbosity level: 0 is silent, higher values show more progress.
+        **_ : object
+            Ignored, kept for signature compatibility with the base class.
+
+        Returns
+        -------
+        int
+            Number of bytes transferred.
+
+        """
+        return upload_file(source, target, overwrite, resume, verbosity)
+
+
+def download(
+    source: str,
+    target: str,
+    *args: bool | int,
+    **kwargs: bool | int,
+) -> Loader:
+    """Download a blob or prefix from Azure Blob Storage to a local path via transfer.
+
+    Parameters
+    ----------
+    source : str
+        Azure Blob Storage URL. Ends with '/' for a prefix download.
+    target : str
+        Local file or directory path.
+    *args : bool | int
+        Additional positional arguments passed through to transfer.
+    **kwargs : bool | int
+        Additional keyword arguments passed through to transfer.
+
+    Returns
+    -------
+    Loader
+        Loader that performs and reports on the transfer when iterated.
+
+    """
+    _assert_azure_url(source)
+    return transfer(source, target, *args, **kwargs)
+
+
+def download_file(source: str, target: str, overwrite: bool, resume: bool, verbosity: int) -> int:
+    """Download a single blob to a local file path.
+
+    The download is retried up to three times on errors other than FileNotFoundError, which is raised immediately
+    without retry.
+
+    Parameters
+    ----------
+    source : str
+        Azure Blob Storage URL for the blob to download.
+    target : str
+        Local file path to write.
+    overwrite : bool
+        If True, replace any existing file at the target path.
+    resume : bool
+        If True, skip the download when a file of the expected size already exists at the target.
+    verbosity : int
+        Verbosity level: 0 is silent, higher values show more progress.
+
+    Returns
+    -------
+    int
+        Number of bytes transferred.
+
+    Raises
+    ------
+    ValueError
+        If a file already exists at the target and neither overwrite nor resume is set.
+    FileNotFoundError
+        If no blob exists at the source URL.
+    OSError
+        If the download fails three times consecutively for reasons other than the blob being missing.
+
+    """
+    obj = _azure_object(source)
+    client = azure_client(obj)
+    size = object_info(obj)["size"]
+
+    if verbosity > 0:
+        LOG.info("Download %s to %s (%s)", source, target, bytes_to_human(size))
+    if overwrite:
+        resume = False
+
+    if (tgt_exists := Path(target).exists()) and resume:
+        local_size = Path(target).stat().st_size
+        if local_size != size:
+            LOG.warning(
+                "%s already exists with different size, re-downloading (remote=%s, local=%s)",
+                target,
+                size,
+                local_size,
+            )
+        else:
+            return size
+
+    if tgt_exists and not overwrite and not resume:
+        msg = f"{target} already exists, use 'overwrite' to replace or 'resume' to skip"
+        raise ValueError(msg)
+
+    last_exc = None
+    for attempt in range(3):
+        try:
+            with (
+                tqdm.tqdm(
+                    desc=obj.path,
+                    total=size,
+                    unit="B",
+                    unit_scale=True,
+                    unit_divisor=1024,
+                    leave=verbosity >= 2,
+                    delay=0 if verbosity > 0 else 10,
+                ) as pbar,
+                Path(target).open("wb") as g,
+            ):
+                g.write(obstore.get(client, obj.path).bytes())
+                pbar.update(size)
+        except FileNotFoundError:
+            raise
+        except Exception as e:
+            last_exc = e
+            LOG.exception("Download attempt %s/3 failed for %s.", attempt + 1, source)
+        else:
+            return size
+
+    msg = f"Failed to download {source} after 3 attempts: {last_exc}"
+    raise OSError(msg)
+
+
+class AzureDownload(BaseDownload):
+    """Transfer implementation for downloading blobs and prefixes from Azure Blob Storage."""
+
+    def copy(self, source: str, target: str, **kwargs: Any) -> None:  # noqa: ANN401
+        """Copy a single blob or all blobs under a prefix to a local path.
+
+        Dispatches to transfer_folder if source ends with '/', otherwise transfer_file.
+
+        Parameters
+        ----------
+        source : str
+            Azure Blob Storage URL. Treated as a prefix if it ends with '/', otherwise as a single blob.
+        target : str
+            Local file or directory path.
+        **kwargs
+            Additional keyword arguments forwarded to the underlying transfer.
+
+        """
+        _assert_azure_url(source)
+        if source.endswith("/"):
+            self.transfer_folder(source=source, target=target, **kwargs)
+        else:
+            self.transfer_file(source=source, target=target, **kwargs)
+
+    def list_source(self, source: str) -> Iterable[ObjectMeta]:
+        """List blobs under the source URL prefix.
+
+        Parameters
+        ----------
+        source : str
+            Azure Blob Storage URL used as a prefix.
+
+        Yields
+        ------
+        ObjectMeta
+            One item per blob under the prefix.
+
+        """
+        yield from _list_objects(source)
+
+    def source_path(self, az_object: ObjectMeta, source: str) -> str:  # type: ignore[override]
+        """Build the Azure Blob Storage URL for a single blob within source.
+
+        Parameters
+        ----------
+        az_object : ObjectMeta
+            Metadata for a single blob returned by list_source.
+        source : str
+            Azure Blob Storage URL used as a prefix.
+
+        Returns
+        -------
+        str
+            Full abfs:// URL for the blob, in container/path form.
+
+        """
+        obj = _azure_object(source)
+        return f"{_ABFS_SCHEME}{obj.container}/{az_object['path']}"
+
+    def target_path(self, az_object: ObjectMeta, source: str, target: str) -> str:  # type: ignore[override]
+        """Build the local file path for a single blob, creating parent directories as needed.
+
+        Parameters
+        ----------
+        az_object : ObjectMeta
+            Metadata for a single blob returned by list_source.
+        source : str
+            Azure Blob Storage URL used as a prefix.
+        target : str
+            Local directory into which the blob should be written.
+
+        Returns
+        -------
+        str
+            Local path at which the blob will be written.
+
+        """
+        obj = _azure_object(source)
+        # os.path.relpath (rather than Path.relative_to) so paths outside the source
+        # prefix walk up with "..", avoiding the walk_up kwarg only added in 3.12
+        local_path = Path(target) / os.path.relpath(az_object["path"], obj.path)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        return str(local_path)
+
+    def source_size(self, az_object: ObjectMeta) -> int:  # type: ignore[override]
+        """Return the size in bytes of a single blob.
+
+        Parameters
+        ----------
+        az_object : ObjectMeta
+            Metadata for a single blob returned by list_source.
+
+        Returns
+        -------
+        int
+            Size of the blob in bytes.
+
+        """
+        return az_object["size"]
+
+    def _transfer_file(
+        self,
+        source: str,
+        target: str,
+        overwrite: bool,
+        resume: bool,
+        verbosity: int,
+        **_: object,
+    ) -> int:
+        """Download a single blob to a local file path.
+
+        Parameters
+        ----------
+        source : str
+            Azure Blob Storage URL for the blob to download.
+        target : str
+            Local file path to write.
+        overwrite : bool
+            If True, replace any existing file at the target path.
+        resume : bool
+            If True, skip the download when a file of the expected size already exists at the target.
+        verbosity : int
+            Verbosity level: 0 is silent, higher values show more progress.
+        **_ : object
+            Ignored, kept for signature compatibility with the base class.
+
+        Returns
+        -------
+        int
+            Number of bytes transferred.
+
+        """
+        return download_file(source, target, overwrite, resume, verbosity)

--- a/src/anemoi/utils/remote/s3.py
+++ b/src/anemoi/utils/remote/s3.py
@@ -37,6 +37,7 @@ import tqdm
 
 from ..humanize import bytes_to_human
 from ..settings import SETTINGS
+from ..settings_schema.object_storage import S3_CLIENT_FIELDS
 from ..settings_schema.object_storage import ObjectStorageBucketConfig
 from . import BaseDownload
 from . import BaseUpload
@@ -117,21 +118,14 @@ def _s3_options(obj: str | S3Object) -> ObjectStorageBucketConfig:
     # Use anemoi.utils.settings to get the configuration
 
     object_storage_cfg = SETTINGS.object_storage
-    keys_of_buckets = [
-        k
-        for k in object_storage_cfg.model_dump(by_alias=False).keys()
-        if k not in ("type", "endpoint_url", "access_key_id", "secret_access_key")
-    ]
+    bucket_overrides = object_storage_cfg.__pydantic_extra__ or {}
 
     candidate: ObjectStorageBucketConfig | None = None
-    for key in keys_of_buckets:
+    for key in bucket_overrides:
         if fnmatch.fnmatch(obj.bucket, key):
             if candidate is not None:
                 raise ValueError(f"Multiple object storage configurations match {obj.bucket}: {candidate} and {key}")
-            candidate = getattr(object_storage_cfg, key)
-
-    if object_storage_cfg.type != "s3":
-        raise ValueError(f"Unsupported object storage type {object_storage_cfg.type}")
+            candidate = bucket_overrides[key]
 
     def _drop_empty(d: dict[str, Any]) -> dict[str, Any]:
         return {k: v for k, v in d.items() if v is not None}
@@ -140,13 +134,7 @@ def _s3_options(obj: str | S3Object) -> ObjectStorageBucketConfig:
         config = _drop_empty(candidate.model_dump(by_alias=False, exclude_none=True))
     else:
         LOG.debug(f"No specific object storage configuration found for bucket {obj.bucket}, using global settings")
-        config = _drop_empty(
-            {
-                k: v
-                for k, v in object_storage_cfg.model_dump(by_alias=False, exclude_none=True).items()
-                if k in ("endpoint_url", "access_key_id", "secret_access_key")
-            }
-        )
+        config = object_storage_cfg.model_dump(by_alias=False, exclude_none=True, include=set(S3_CLIENT_FIELDS))
 
     resolved_object_config = ObjectStorageBucketConfig(**config)
 
@@ -175,7 +163,7 @@ def s3_client(obj: str | S3Object) -> Any:
     import obstore
 
     def resolve_secrets(options: ObjectStorageBucketConfig) -> dict[str, Any]:
-        resolved_keys = options.model_dump(by_alias=False, exclude_none=True)
+        resolved_keys = options.model_dump(by_alias=False, exclude_none=True, include=set(S3_CLIENT_FIELDS))
         if options.access_key_id is not None:
             resolved_keys["access_key_id"] = options.access_key_id.get_secret_value()
         if options.secret_access_key is not None:

--- a/src/anemoi/utils/settings.py
+++ b/src/anemoi/utils/settings.py
@@ -327,7 +327,7 @@ class AnemoiSettings(BaseSettings):
     ## ---------- Setting fields ---------- ##
 
     object_storage: ObjectStorageConfig = Field(default_factory=ObjectStorageConfig, alias="object-storage")
-    """Configuration for S3-compatible object storage."""
+    """Configuration for cloud (S3-compatible and Azure Blob) object storage."""
 
     datasets: DatasetsConfig = Field(default_factory=DatasetsConfig)
     """Dataset discovery and validation settings."""

--- a/src/anemoi/utils/settings_schema/object_storage.py
+++ b/src/anemoi/utils/settings_schema/object_storage.py
@@ -7,39 +7,77 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-from typing import Optional
+"""Pydantic models for object storage configuration."""
+
+import warnings
+from typing import Literal
 
 from pydantic import Field
 from pydantic import SecretStr
+from pydantic import field_validator
+from pydantic import model_validator
 
 from .base import AnemoiBaseSettingsSchema
 
+# ObjectStorageBucketConfig fields each backend consumes when building clients
+_COMMON_CLIENT_FIELDS = frozenset({"endpoint_url", "skip_signature"})
+_S3_ONLY_FIELDS = frozenset({"access_key_id", "secret_access_key", "region"})
+_AZURE_ONLY_FIELDS = frozenset({"account_name", "account_key", "sas_token"})
+S3_CLIENT_FIELDS = _COMMON_CLIENT_FIELDS | _S3_ONLY_FIELDS
+AZURE_CLIENT_FIELDS = _COMMON_CLIENT_FIELDS | _AZURE_ONLY_FIELDS
+
+
+def _reject_mixed_backends(instance: AnemoiBaseSettingsSchema) -> None:
+    """Raise if both S3-only and Azure-only fields are set on the same config."""
+    s3_set = {f for f in _S3_ONLY_FIELDS if getattr(instance, f, None) is not None}
+    az_set = {f for f in _AZURE_ONLY_FIELDS if getattr(instance, f, None) is not None}
+    if s3_set and az_set:
+        msg = (
+            f"Mixed S3 and Azure fields on the same object storage config: S3 fields = {sorted(s3_set)}, Azure fields "
+            f"= {sorted(az_set)}. Configure one backend per bucket/account."
+        )
+        raise ValueError(msg)
+
 
 class ObjectStorageBucketConfig(AnemoiBaseSettingsSchema):
-    """Per-bucket overrides for object storage configuration."""
+    """Object storage configuration for S3-compatible and Azure Blob services.
 
-    endpoint_url: Optional[str] = None
-    """Bucket-specific endpoint URL."""
+    At the top level (:class:`ObjectStorageConfig`) these fields act as global defaults. Under a named sub-section (e.g.
+    `[object-storage."my-bucket"]`) they act as per-bucket/account overrides.
+    """
 
-    access_key_id: Optional[SecretStr] = None
-    """Bucket-specific access key ID."""
+    # common fields
+    endpoint_url: str | None = None
+    """Endpoint URL. S3-compatible services, Azurite or sovereign clouds for Azure."""
+    skip_signature: bool | None = False
+    """Skip signature for public storage."""
 
-    secret_access_key: Optional[SecretStr] = None
-    """Bucket-specific secret access key."""
+    # S3 fields
+    access_key_id: SecretStr | None = None
+    """S3 bucket access key ID."""
+    secret_access_key: SecretStr | None = None
+    """S3 bucket secret access key."""
+    region: str | None = None
+    """S3 bucket region."""
 
-    region: Optional[str] = None
-    """Bucket-specific region."""
+    # Azure Blob Storage fields
+    account_name: SecretStr | None = None
+    """Azure Blob Storage account name."""
+    account_key: SecretStr | None = None
+    """Azure Blob Storage account key."""
+    sas_token: SecretStr | None = None
+    """Azure Blob Storage SAS token. May include or omit the leading '?'."""
 
-    skip_signature: Optional[bool] = False
-    """Skip signature for public buckets."""
+    @model_validator(mode="after")
+    def _no_mixed_backends(self) -> "ObjectStorageBucketConfig":
+        _reject_mixed_backends(self)
+        return self
 
-    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+    def get(self, key: str, default: str | None = None) -> str | None:
         """Get a configuration value with fallback to the global setting."""
-        import warnings
-
         warnings.warn(
-            "ObjectStorageBucketConfig.get() is deprecated and will be removed in a future version. "
-            "Access bucket-specific settings directly as attributes, rather than viewing this as a dictionary.",
+            f"{type(self).__name__}.get() is deprecated and will be removed in a future version. Access settings "
+            "directly as attributes, rather than viewing this as a dictionary.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -49,34 +87,25 @@ class ObjectStorageBucketConfig(AnemoiBaseSettingsSchema):
         return default
 
 
-class ObjectStorageConfig(AnemoiBaseSettingsSchema):
-    """Object storage configuration for S3-compatible services."""
+class ObjectStorageConfig(ObjectStorageBucketConfig):
+    """Top-level, global object storage configuration.
 
-    type: str = "s3"
-    """Default storage type (only 's3' is currently supported)."""
+    Inherits all backend fields from :class:`ObjectStorageBucketConfig` used for per-bucket/account overrides under
+    `__pydantic_extra__` (named sub-sections, e.g. `[object-storage."my-bucket"]`).
+    """
 
-    endpoint_url: Optional[str] = None
-    """Global endpoint URL (leave empty for default AWS endpoint)."""
-
-    access_key_id: Optional[SecretStr] = None
-    """Global access key ID."""
-
-    secret_access_key: Optional[SecretStr] = None
-    """Global secret access key."""
+    type: Literal["s3", "az"] | None = None
+    """Deprecated: retained for backwards compatibility. Backends are dispatched by URL scheme (`s3://`, `abfs://`)."""
 
     __pydantic_extra__: dict[str, ObjectStorageBucketConfig] = Field(init=False)  # type: ignore[assignment]
 
-    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
-        """Get a configuration value with fallback to the global setting."""
-        import warnings
-
-        warnings.warn(
-            "ObjectStorageConfig.get() is deprecated and will be removed in a future version. "
-            "Access settings directly as attributes, rather than viewing this as a dictionary.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        value = getattr(self, key)
-        if value is not None and value != "":
-            return value
-        return default
+    @field_validator("type", mode="after")
+    @classmethod
+    def _warn_deprecated_type(cls, value: str | None) -> None:
+        if value is not None:
+            warnings.warn(
+                "The 'type' field on [object-storage] is deprecated and ignored. Backend is chosen by URL scheme "
+                "('s3://' or 'abfs://'). Remove it from your settings file.",
+                DeprecationWarning,
+                stacklevel=2,
+            )

--- a/src/anemoi/utils/settings_schema/settings.defaults.toml
+++ b/src/anemoi/utils/settings_schema/settings.defaults.toml
@@ -47,10 +47,10 @@
 # =============================================================================
 [object-storage]
 
-# Default storage type (only "s3" is currently supported).
+# Cloud storage type, deprecated - backend now inferred from URL scheme (e.g., s3://, abfs://).
 type = "s3"
 
-# Global endpoint URL.  Leave empty to use the default AWS endpoint.
+# Global endpoint URL. Leave empty to use the default endpoint for the storage service.
 endpoint_url = ""
 
 # Global credentials.
@@ -78,7 +78,13 @@ endpoint_url = ""
 # secret_access_key = ""
 # region = "eu-north-1"
 # skip_signature = true
-
+#
+# [object-storage."some-public-bucket-on-azure"]
+# endpoint_url = ""
+# account_name = ""
+# account_key = ""
+# sas_token = ""
+# skip_signature = true
 
 # =============================================================================
 # [datasets]  —  Dataset discovery & validation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+# (C) Copyright 2024-2026 Anemoi contributors.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import contextlib
+from collections.abc import Generator
+from functools import partial
+
+import pytest
+from pydantic import SecretStr
+
+from anemoi.utils.remote import az
+from anemoi.utils.settings import SETTINGS
+from anemoi.utils.settings_schema.object_storage import ObjectStorageConfig
+from tests.helpers.azurite import AZURITE_ACCOUNT_KEY
+from tests.helpers.azurite import AZURITE_ACCOUNT_NAME
+from tests.helpers.azurite import AZURITE_BLOB_BODY
+from tests.helpers.azurite import AZURITE_BLOB_NAME
+from tests.helpers.azurite import AZURITE_CONTAINER
+from tests.helpers.azurite import AZURITE_ENDPOINT
+from tests.helpers.azurite import create_container
+
+
+@pytest.fixture(scope="session")
+def azurite() -> Generator[None]:
+    """Test session-scoped fixture to set up Azurite and anemoi configuration for testing.
+
+    Seeds a known blob for testing existence, listing and metadata retrieval.
+    """
+    import obstore  # noqa: PLC0415
+
+    create_container(AZURITE_CONTAINER)
+
+    # patch from_url in test and anemoi.utils.remote.az to allow http for Azurite
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(obstore.store, "from_url", partial(obstore.store.from_url, client_options={"allow_http": True}))
+        original = SETTINGS.object_storage
+        SETTINGS.object_storage = ObjectStorageConfig(
+            account_name=SecretStr(AZURITE_ACCOUNT_NAME),
+            account_key=SecretStr(AZURITE_ACCOUNT_KEY),
+            endpoint_url=f"{AZURITE_ENDPOINT.rstrip('/')}/{AZURITE_ACCOUNT_NAME}",
+        )
+        az.CLIENT_CACHE.clear()
+        store = None
+        try:
+            store = obstore.store.from_url(
+                f"abfs://{AZURITE_CONTAINER}",
+                account_name=AZURITE_ACCOUNT_NAME,
+                account_key=AZURITE_ACCOUNT_KEY,
+                endpoint=f"{AZURITE_ENDPOINT.rstrip('/')}/{AZURITE_ACCOUNT_NAME}",
+            )
+            obstore.put(store, AZURITE_BLOB_NAME, AZURITE_BLOB_BODY)
+            yield
+        finally:
+            if store is not None:
+                with contextlib.suppress(Exception):
+                    obstore.delete(store, AZURITE_BLOB_NAME)
+            SETTINGS.object_storage = original
+            az.CLIENT_CACHE.clear()

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,8 @@
+# (C) Copyright 2026 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.

--- a/tests/helpers/azurite.py
+++ b/tests/helpers/azurite.py
@@ -1,0 +1,83 @@
+# (C) Copyright 2024-2026 Anemoi contributors.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Helper functionality for testing with Azurite (Azure Blob Storage emulator)."""
+
+import base64
+import hashlib
+import hmac
+import os
+import socket
+import uuid
+from datetime import UTC
+from datetime import datetime
+from urllib.error import HTTPError
+from urllib.parse import urlparse
+from urllib.request import Request
+from urllib.request import urlopen
+
+# Azurite defaults
+AZURITE_ENDPOINT = os.environ.get("AZURITE_BLOB_ENDPOINT", "http://127.0.0.1:10000/")
+AZURITE_ACCOUNT_NAME = os.environ.get("AZURITE_ACCOUNT_NAME", "devstoreaccount1")
+AZURITE_ACCOUNT_KEY = os.environ.get(
+    "AZURITE_ACCOUNT_KEY",
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
+)
+AZURITE_API_VERSION = "2023-11-03"
+AZURITE_CONTAINER = "anemoi-utils-tests"
+AZURITE_BLOB_NAME = f"test-{uuid.uuid4()}.txt"
+AZURITE_BLOB_URL = f"abfs://{AZURITE_CONTAINER}/{AZURITE_BLOB_NAME}"
+AZURITE_BLOB_BODY = b"anemoi-utils test blob for Azure Blob Storage unit tests."
+
+
+def azurite_reachable() -> bool:
+    """Return True if Azurite is reachable at the configured endpoint."""
+    u = urlparse(AZURITE_ENDPOINT)
+    try:
+        with socket.create_connection((u.hostname, u.port or 10000), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+def create_container(name: str) -> None:
+    """Create a container on Azurite using the REST API and Shared Key auth.
+
+    Cannot be done with `obstore` and mitigates extra dependencies like `azure-storage-blob`.
+
+    Ignores HTTP 409 (already exists).
+    See https://learn.microsoft.com/rest/api/storageservices/create-container
+    """
+    date = datetime.now(UTC).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    canon_headers = f"x-ms-date:{date}\nx-ms-version:{AZURITE_API_VERSION}\n"
+    canon_resource = f"/{AZURITE_ACCOUNT_NAME}/{AZURITE_ACCOUNT_NAME}/{name}\nrestype:container"
+    string_to_sign = "\n".join(["PUT", *([""] * 11)]) + "\n" + canon_headers + canon_resource
+    key = base64.b64decode(AZURITE_ACCOUNT_KEY)
+    signature = base64.b64encode(hmac.new(key, string_to_sign.encode("utf-8"), hashlib.sha256).digest()).decode()
+
+    url = f"{AZURITE_ENDPOINT.rstrip('/')}/{AZURITE_ACCOUNT_NAME}/{name}?restype=container"
+    req = Request(  # noqa: S310
+        url,
+        method="PUT",
+        headers={
+            "x-ms-date": date,
+            "x-ms-version": AZURITE_API_VERSION,
+            "Authorization": f"SharedKey {AZURITE_ACCOUNT_NAME}:{signature}",
+            "Content-Length": "0",
+        },
+    )
+    exists_code = 409
+    created_code = 201
+    url_return = None
+    try:
+        url_return = urlopen(req, timeout=5)  # noqa: S310
+    except HTTPError as e:
+        if e.code != exists_code:
+            raise
+    if url_return is not None and url_return.status != created_code:
+        msg = f"Failed to create container {name} on Azurite: {url_return.status} {url_return.reason}"
+        raise RuntimeError(msg)

--- a/tests/test_az.py
+++ b/tests/test_az.py
@@ -1,0 +1,83 @@
+# (C) Copyright 2024-2026 Anemoi contributors.
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+"""Unit tests for Azure Blob Storage remote utilities.
+
+Requires the Azurite blob service running locally, e.g. via `testcontainers` or the VS Code extension.
+"""
+
+import os
+
+import pytest
+
+from anemoi.utils.remote import az
+from anemoi.utils.testing import skip_missing_packages
+from tests.helpers.azurite import AZURITE_ACCOUNT_NAME
+from tests.helpers.azurite import AZURITE_BLOB_BODY
+from tests.helpers.azurite import AZURITE_BLOB_NAME
+from tests.helpers.azurite import AZURITE_BLOB_URL
+from tests.helpers.azurite import AZURITE_CONTAINER
+from tests.helpers.azurite import AZURITE_ENDPOINT
+from tests.helpers.azurite import azurite_reachable
+
+IN_CI = (os.environ.get("GITHUB_WORKFLOW") is not None) or (os.environ.get("IN_CI_HPC") is not None)
+pytestmark = [
+    pytest.mark.skipif(IN_CI, reason="Test requires access to Azurite not available in CI"),
+    skip_missing_packages("obstore"),
+    pytest.mark.skipif(not azurite_reachable(), reason=f"Azurite not reachable at endpoint: {AZURITE_ENDPOINT}"),
+]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        AZURITE_BLOB_URL,
+        f"abfs://{AZURITE_CONTAINER}@{AZURITE_ACCOUNT_NAME}.blob.core.windows.net/{AZURITE_BLOB_NAME}",
+        f"abfs://{AZURITE_CONTAINER}@{AZURITE_ACCOUNT_NAME}.dfs.core.windows.net/{AZURITE_BLOB_NAME}",
+        f"abfs://{AZURITE_CONTAINER}@{AZURITE_ACCOUNT_NAME}.dfs.core.windows.net/{AZURITE_BLOB_NAME}?sv=abc123",
+    ],
+)
+def test_assert_azure_url_valid(azurite: None, url: str) -> None:
+    """Test detection of supported Azure Blob Storage URLs."""
+    az._assert_azure_url(url)  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "s3://my-bucket/my-object",
+        "https://my-bucket.s3.amazonaws.com/my-object",
+        "https://example.com/path/to/resource",
+        f"https://{AZURITE_ACCOUNT_NAME}.blob.core.windows.net/{AZURITE_CONTAINER}/{AZURITE_BLOB_NAME}",
+    ],
+)
+def test_assert_azure_url_invalid(azurite: None, url: str) -> None:
+    """Test detection of unsupported Azure Blob Storage URLs."""
+    with pytest.raises(ValueError, match="Invalid Azure URL:"):
+        az._assert_azure_url(url)  # noqa: SLF001
+
+
+def test_object_exists(azurite: None) -> None:
+    """Test existence of objects in Azure Blob Storage."""
+    assert az.object_exists(AZURITE_BLOB_URL) is True
+    assert az.object_exists("abfs://ml-datasets/does-not-exist") is False
+
+
+def test_list_folder(azurite: None) -> None:
+    """Test listing of objects in Azure Blob Storage."""
+    assert len(list(az.list_folder(f"abfs://{AZURITE_CONTAINER}/"))) == 1
+
+
+def test_object_info(azurite: None) -> None:
+    """Test retrieval of metadata for an object in Azure Blob Storage."""
+    info = az.object_info(AZURITE_BLOB_URL)
+    assert info["path"] == AZURITE_BLOB_NAME
+
+
+def test_get_object(azurite: None) -> None:
+    """Test retrieval of contents for an object in Azure Blob Storage."""
+    body = az.get_object(AZURITE_BLOB_URL)
+    assert body == AZURITE_BLOB_BODY

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -15,7 +15,10 @@ import pytest
 from anemoi.utils.remote import TransferMethodNotImplementedError
 from anemoi.utils.remote import _find_transfer_class
 from anemoi.utils.remote import transfer
-from anemoi.utils.testing import packages_installed
+from anemoi.utils.testing import skip_missing_packages
+from tests.helpers.azurite import AZURITE_CONTAINER
+from tests.helpers.azurite import AZURITE_ENDPOINT
+from tests.helpers.azurite import azurite_reachable
 
 IN_CI = (os.environ.get("GITHUB_WORKFLOW") is not None) or (os.environ.get("IN_CI_HPC") is not None)
 
@@ -33,6 +36,7 @@ LOCAL = [
     "/dir",
     "/file",
 ]
+AZ = ["abfs://container/path/", "abfs://container@account.blob.core.windows.net/path"]
 S3 = ["s3://bucket/key/", "s3://bucket/key"]
 SSH = [
     "ssh://hostname:/absolute/file",
@@ -63,6 +67,23 @@ def test_transfer_find_s3_upload(source: str, target: str) -> None:
     assert _find_transfer_class(source, target) == S3Upload
 
 
+@pytest.mark.parametrize("source", LOCAL)
+@pytest.mark.parametrize("target", AZ)
+def test_transfer_find_az_upload(source: str, target: str) -> None:
+    """Test finding the Azure Blob Storage upload transfer class.
+
+    Parameters
+    ----------
+    source : str
+        The source path
+    target : str
+        The target path
+    """
+    from anemoi.utils.remote.az import AzureUpload
+
+    assert _find_transfer_class(source, target) == AzureUpload
+
+
 @pytest.mark.parametrize("source", S3)
 @pytest.mark.parametrize("target", LOCAL)
 def test_transfer_find_s3_download(source: str, target: str) -> None:
@@ -78,6 +99,23 @@ def test_transfer_find_s3_download(source: str, target: str) -> None:
     from anemoi.utils.remote.s3 import S3Download
 
     assert _find_transfer_class(source, target) == S3Download
+
+
+@pytest.mark.parametrize("source", AZ)
+@pytest.mark.parametrize("target", LOCAL)
+def test_transfer_find_az_download(source: str, target: str) -> None:
+    """Test finding the Azure Blob Storage download transfer class.
+
+    Parameters
+    ----------
+    source : str
+        The source path
+    target : str
+        The target path
+    """
+    from anemoi.utils.remote.az import AzureDownload
+
+    assert _find_transfer_class(source, target) == AzureDownload
 
 
 @pytest.mark.parametrize("source", LOCAL)
@@ -97,8 +135,8 @@ def test_transfer_find_ssh_upload(source: str, target: str) -> None:
     assert _find_transfer_class(source, target) == RsyncUpload
 
 
-@pytest.mark.parametrize("source", S3 + SSH)
-@pytest.mark.parametrize("target", S3 + SSH)
+@pytest.mark.parametrize("source", AZ + S3 + SSH)
+@pytest.mark.parametrize("target", AZ + S3 + SSH)
 def test_transfer_find_none(source: str, target: str) -> None:
     """Test that no transfer class is found for unsupported transfers.
 
@@ -114,7 +152,7 @@ def test_transfer_find_none(source: str, target: str) -> None:
 
 
 @pytest.mark.skipif(IN_CI, reason="Test requires access to S3")
-@pytest.mark.skipif(not packages_installed("obstore"), reason="obstore is not installed")
+@skip_missing_packages("obstore")
 def test_transfer_zarr_s3_to_local(tmpdir: pytest.TempPathFactory) -> None:
     """Test transferring a Zarr file from S3 to local.
 
@@ -135,7 +173,7 @@ def test_transfer_zarr_s3_to_local(tmpdir: pytest.TempPathFactory) -> None:
 
 
 @pytest.mark.skipif(IN_CI, reason="Test requires access to S3")
-@pytest.mark.skipif(not packages_installed("obstore"), reason="obstore is not installed")
+@skip_missing_packages("obstore")
 def test_transfer_zarr_local_to_s3(tmpdir: pytest.TempPathFactory) -> None:
     """Test transferring a Zarr file from local to S3.
 
@@ -204,7 +242,7 @@ def compare(local1: str, local2: str) -> None:
 
 
 @pytest.mark.skipif(IN_CI, reason="Test requires access to S3")
-@pytest.mark.skipif(not packages_installed("obstore"), reason="obstore is not installed")
+@skip_missing_packages("obstore")
 @pytest.mark.parametrize("path", ["directory/", "file"])
 def test_transfer_local_to_s3_to_local(path: str) -> None:
     """Test transferring a file or directory from local to S3 and back to local.
@@ -239,6 +277,54 @@ def test_transfer_local_to_s3_to_local(path: str) -> None:
 
         compare(local, local2)
 
+        _delete_file_or_directory(local2)
+
+    finally:
+        delete(remote)
+
+    if remote.endswith("/"):
+        assert len(list(list_folder(remote))) == 0
+    else:
+        assert object_exists(remote) is False
+
+
+@pytest.mark.skipif(IN_CI, reason="Test requires access to Azurite not available in CI")
+@skip_missing_packages("obstore")
+@pytest.mark.skipif(not azurite_reachable(), reason=f"Azurite not reachable at endpoint: {AZURITE_ENDPOINT}")
+@pytest.mark.parametrize("path", ["directory/", "file"])
+def test_transfer_local_to_az_to_local(azurite: None, path: str) -> None:
+    """Test transferring a file or directory from local to Azure Blob Storage and back to local.
+
+    Parameters
+    ----------
+    azurite : None
+        Fixture to set up Azurite and anemoi configuration for testing, see conftest.py.
+    path : str
+        Path to the file or directory to round-trip.
+
+    """
+    from anemoi.utils.remote.az import delete
+    from anemoi.utils.remote.az import list_folder
+    from anemoi.utils.remote.az import object_exists
+
+    local = LOCAL_TEST_DATA + "/" + path
+    remote = f"abfs://{AZURITE_CONTAINER}" + f"/{uuid.uuid4()}/" + path
+    local2 = LOCAL_TEST_DATA + "-copy-" + path
+
+    try:
+        transfer(local, remote, overwrite=True)
+        transfer(local, remote, resume=True)
+        with pytest.raises(ValueError, match="already exists"):
+            transfer(local, remote)
+
+        _delete_file_or_directory(local2)
+        transfer(remote, local2)
+        with pytest.raises(ValueError, match="already exists"):
+            transfer(remote, local2)
+        transfer(local, remote, overwrite=True)
+        transfer(local, remote, resume=True)
+
+        compare(local, local2)
         _delete_file_or_directory(local2)
 
     finally:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -420,6 +420,51 @@ class TestBucketOverrides:
         assert s.object_storage.endpoint_url == "https://global.example.com"
 
 
+class TestObjectStorageConfig:
+    """Tests for the ObjectStorageConfig class."""
+
+    def test_object_storage_raises_on_mixed_backends(self, isolated_settings) -> None:
+        """A bucket config that mixes S3 and Azure fields should raise."""
+        isolated_settings.secrets_toml.write_text(
+            textwrap.dedent(
+                """\
+                [object-storage]
+                access_key_id = "AKIAEXAMPLE"
+                account_name = "azureaccount"
+                """,
+            ),
+        )
+        with pytest.raises(ValueError, match="Mixed S3 and Azure"):
+            isolated_settings.load()
+
+    def test_object_storage_warns_on_type_field(self, isolated_settings) -> None:
+        """Setting the 'type' field in the config should warn."""
+        isolated_settings.toml.write_text(
+            textwrap.dedent(
+                """\
+                [object-storage]
+                type = "s3"
+                """,
+            ),
+        )
+        with pytest.warns(DeprecationWarning, match="is deprecated"):
+            isolated_settings.load()
+
+    def test_object_storage_warns_on_get_method(self, isolated_settings) -> None:
+        """Accessing the 'get' method should warn."""
+        isolated_settings.toml.write_text(
+            textwrap.dedent(
+                """\
+                [object-storage]
+                endpoint_url = "https://global.example.com"
+                """,
+            ),
+        )
+        s = isolated_settings.load()
+        with pytest.warns(DeprecationWarning, match="is deprecated"):
+            s.object_storage.get("endpoint_url")
+
+
 # ---------------------------------------------------------------------------
 # Secret tree detection and splitting
 # ---------------------------------------------------------------------------

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -434,6 +434,7 @@ class TestObjectStorageConfig:
                 """,
             ),
         )
+        isolated_settings.secrets_toml.chmod(0o600)
         with pytest.raises(ValueError, match="Mixed S3 and Azure"):
             isolated_settings.load()
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -423,6 +423,7 @@ class TestBucketOverrides:
 class TestObjectStorageConfig:
     """Tests for the ObjectStorageConfig class."""
 
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permissions only")
     def test_object_storage_raises_on_mixed_backends(self, isolated_settings) -> None:
         """A bucket config that mixes S3 and Azure fields should raise."""
         isolated_settings.secrets_toml.write_text(


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->

Addition of Azure Blob Storage as a data download source and upload destination.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

New feature requiring minor updates to existing auxiliary code, no breaking changes. Deprecation of the `s3` dependency group (in favour of the more representative `remote`) and the Anemoi settings object storage configuration's `type` field.

## What issue or task does this change relate to?
<!-- link to Issue Number -->
Closes #277 

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

Addresses part of the issue in that Azure Blob Storage is now a functional source and destination for data in anemoi. Two caveats relative to the issue:

- Azure ML URLs are usable with Azure ML alone. The platform aliases containers as datastores. Programmatically resolving the datastore alias to its true container name (which can be the same but is not guaranteed) requires the `az` CLI (and `ml` extension) or `azure-ai-ml` SDK. Azure ML URLs are relatively straightforward to resolve manually should the container-datastore alias be known. For now, I thought to avoid additional, limited use dependencies and include wider Azure support with standard `abfs` scheme URLs.
- The issue looks to request streaming from one cloud's storage service to another. This hasn't been implemented here as it's not Azure-specific and perhaps more appropriate to address in a separate contribution, which I'd be happy to look into.

This does not add support for every Azure Blob Storage URL format but to those prefixed `abfs://` and using the `<container>/<path>` or `<container>@<account>.<service>.<endpoint>/<path>` structures. This aligns with that for `anemoi.utils.remote.s3` (`s3://` only) and mitigates accounting for every `obstore`-supported scheme (e.g. abfss, adls, az, HTTPS).

Requires [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) to run tests. Added set-up (not install) thereof to tests/helpers/azurite.py and a fixture to conftest.py. Confirmed S3 tests still pass with MinIO and mock data (I do not have access to the test data bucket).

Only the deprecated `anemoi.utils.s3` has RST documentation under doc/modules. The S3 equivalent to this contribution does not. As such, I have not added a docs file for az.py but can if desired.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
