### PR TITLE
feat: add command to dump the model structure from a checkpoint

### DIFF
--- a/docs/cli/config.rst
+++ b/docs/cli/config.rst
@@ -1,0 +1,9 @@
+config
+------
+
+
+.. argparse::
+    :module: anemoi.utils.__main__
+    :func: create_parser
+    :prog: anemoi-utils
+    :path: config

--- a/docs/cli/metadata.rst
+++ b/docs/cli/metadata.rst
@@ -1,0 +1,9 @@
+metadata
+--------
+
+
+.. argparse::
+    :module: anemoi.utils.__main__
+    :func: create_parser
+    :prog: anemoi-utils
+    :path: metadata

--- a/docs/cli/requests.rst
+++ b/docs/cli/requests.rst
@@ -1,0 +1,9 @@
+requests
+--------
+
+
+.. argparse::
+    :module: anemoi.utils.__main__
+    :func: create_parser
+    :prog: anemoi-utils
+    :path: requests

--- a/docs/cli/settings.rst
+++ b/docs/cli/settings.rst
@@ -1,9 +1,9 @@
-config
-------
+settings
+--------
 
 
 .. argparse::
     :module: anemoi.utils.__main__
     :func: create_parser
     :prog: anemoi-utils
-    :path: config
+    :path: settings

--- a/docs/cli/transfer.rst
+++ b/docs/cli/transfer.rst
@@ -1,0 +1,9 @@
+transfer
+--------
+
+
+.. argparse::
+    :module: anemoi.utils.__main__
+    :func: create_parser
+    :prog: anemoi-utils
+    :path: transfer

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,6 +87,16 @@ Text & table formatting
    modules/text
 
 .. toctree::
+   :maxdepth: 1
+   :caption: CLI
+   :hidden:
+
+   cli/config
+   cli/metadata
+   cli/requests
+   cli/transfer
+
+.. toctree::
    :maxdepth: 2
    :caption: API Reference
    :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -91,7 +91,7 @@ Text & table formatting
    :caption: CLI
    :hidden:
 
-   cli/config
+   cli/settings
    cli/metadata
    cli/requests
    cli/transfer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ optional-dependencies.docs = [
   "autodoc-pydantic>=2.2",
   "nbsphinx",
   "pandoc",
+  "pytest",
   "requests",
   "sphinx",
   "sphinx-argparse",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "filelock",
   "multiurl",
   "numpy",
+  "peekle",
   "pydantic>=2.9",
   "pydantic-settings>=2.14.1",
   "python-dateutil",

--- a/src/anemoi/utils/checkpoints.py
+++ b/src/anemoi/utils/checkpoints.py
@@ -393,7 +393,7 @@ def remove_metadata(path: str, *, name: str = DEFAULT_NAME) -> None:
     return _edit_metadata(path, name, callback)
 
 
-def unpickle_model(path):
+def unpickle_model(path, **kwargs) -> dict:
     import io
 
     from peekle import Peekle
@@ -407,4 +407,4 @@ def unpickle_model(path):
         data = zipf.read(data_files[0])
 
     parsed = Peekle.parse(io.BytesIO(data))
-    return parsed.to_json(function_calls=True, shorten_strings=True, bytes_count=True)
+    return parsed.to_json(**kwargs)

--- a/src/anemoi/utils/checkpoints.py
+++ b/src/anemoi/utils/checkpoints.py
@@ -391,3 +391,20 @@ def remove_metadata(path: str, *, name: str = DEFAULT_NAME) -> None:
         os.remove(full)
 
     return _edit_metadata(path, name, callback)
+
+
+def unpickle_model(path):
+    import io
+
+    from peekle import Peekle
+
+    with zipfile.ZipFile(path, "r") as zipf:
+        data_files = [name for name in zipf.namelist() if os.path.basename(name) == "data.pkl"]
+        if len(data_files) == 0:
+            raise FileNotFoundError(f"Could not find 'data.pkl' in {path}.")
+        if len(data_files) > 1:
+            raise ValueError(f"Found two or more 'data.pkl' in {path}.")
+        data = zipf.read(data_files[0])
+
+    parsed = Peekle.parse(io.BytesIO(data))
+    return parsed.to_json(function_calls=True, shorten_strings=True, bytes_count=True)

--- a/src/anemoi/utils/commands/metadata.py
+++ b/src/anemoi/utils/commands/metadata.py
@@ -103,9 +103,9 @@ class Metadata(Command):
         )
 
         group.add_argument(
-            "--unpickle",
+            "--peek",
             action="store_true",
-            help=("Unpickle the model."),
+            help=("Peek into the pickled model."),
         )
 
         command_parser.add_argument(
@@ -183,8 +183,8 @@ class Metadata(Command):
         if args.supporting_arrays:
             return self.supporting_arrays(args)
 
-        if args.unpickle:
-            return self.unpickle(args)
+        if args.peek:
+            return self.peek(args)
 
     def edit(self, args: Namespace) -> None:
         """Edit the metadata in place using the specified editor.
@@ -397,8 +397,8 @@ class Metadata(Command):
         for name, array in supporting_arrays.items():
             print(f"{name}: shape={array.shape} dtype={array.dtype}")
 
-    def unpickle(self, args: Namespace) -> None:
-        """Unpickle the model from the checkpoint.
+    def peek(self, args: Namespace) -> None:
+        """Peek into the pickled model from the checkpoint.
 
         Parameters
         ----------
@@ -407,7 +407,12 @@ class Metadata(Command):
         """
         from anemoi.utils.checkpoints import unpickle_model
 
-        model = unpickle_model(args.path)
+        kwargs = dict(
+            # function_calls=True,
+            bytes_count=True
+        )
+
+        model = unpickle_model(args.path, **kwargs)
         if args.yaml:
             print(yaml.dump(model, indent=2))
         else:

--- a/src/anemoi/utils/commands/metadata.py
+++ b/src/anemoi/utils/commands/metadata.py
@@ -102,6 +102,12 @@ class Metadata(Command):
             help=("Extract the metadata from the checkpoint so it can be added to the test suite."),
         )
 
+        group.add_argument(
+            "--unpickle",
+            action="store_true",
+            help=("Unpickle the model."),
+        )
+
         command_parser.add_argument(
             "--name",
             default=DEFAULT_NAME,
@@ -110,7 +116,7 @@ class Metadata(Command):
 
         command_parser.add_argument(
             "--input",
-            help="The output file name to be used by the ``--load`` option.",
+            help="The input file name to be used by the ``--load`` option.",
         )
 
         command_parser.add_argument(
@@ -176,6 +182,9 @@ class Metadata(Command):
 
         if args.supporting_arrays:
             return self.supporting_arrays(args)
+
+        if args.unpickle:
+            return self.unpickle(args)
 
     def edit(self, args: Namespace) -> None:
         """Edit the metadata in place using the specified editor.
@@ -387,6 +396,22 @@ class Metadata(Command):
 
         for name, array in supporting_arrays.items():
             print(f"{name}: shape={array.shape} dtype={array.dtype}")
+
+    def unpickle(self, args: Namespace) -> None:
+        """Unpickle the model from the checkpoint.
+
+        Parameters
+        ----------
+        args : Namespace
+            The arguments passed to the command.
+        """
+        from anemoi.utils.checkpoints import unpickle_model
+
+        model = unpickle_model(args.path)
+        if args.yaml:
+            print(yaml.dump(model, indent=2))
+        else:
+            print(json.dumps(model, indent=2))
 
 
 command = Metadata

--- a/src/anemoi/utils/compatibility.py
+++ b/src/anemoi/utils/compatibility.py
@@ -39,14 +39,14 @@ def aliases(aliases: dict[str, str | list[str]] | None = None, **kwargs: Any) ->
 
     Examples
     --------
-    ```python
-    @aliases(a="b", c=["d", "e"])
-    def func(a, c):
-        return a, c
+    ::
 
-    func(a=1, c=2)  # (1, 2)
-    func(b=1, d=2)  # (1, 2)
-    ```
+        @aliases(a="b", c=["d", "e"])
+        def func(a, c):
+            return a, c
+
+        func(a=1, c=2)  # (1, 2)
+        func(b=1, d=2)  # (1, 2)
     """
 
     if aliases is None:

--- a/src/anemoi/utils/testing.py
+++ b/src/anemoi/utils/testing.py
@@ -338,7 +338,7 @@ def cli_testing(package: str, cmd: str, *args: str) -> None:
 
 
 def run_tests(globals: dict[str, Callable[[], None]]) -> None:
-    """Run all test functions that start with 'test_'.
+    """Run all test functions that start with ``test_``.
 
     Parameters
     ----------
@@ -347,14 +347,11 @@ def run_tests(globals: dict[str, Callable[[], None]]) -> None:
 
     Example
     -------
+    Call from a test file to run all tests in that file::
 
-    Call from a test file to run all tests in that file:
-
-    ```python
-    if __name__ == "__main__":
-        from anemoi.utils.testing import run_tests
-        run_tests(globals())
-    ```
+        if __name__ == "__main__":
+            from anemoi.utils.testing import run_tests
+            run_tests(globals())
 
     Useful for debugging or running tests in an interactive environment.
 


### PR DESCRIPTION
## Description

Add a command to decode the pickled model from a checkpoint and dump its content in JSON or YAML. The option is called `peek` as it peeks into the file.

```bash
anemoi-utils metadata --peek checkpoint.ckpt
```

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)


<!-- readthedocs-preview anemoi-utils start -->
----
📚 Documentation preview 📚: https://anemoi-utils--325.org.readthedocs.build/en/325/

<!-- readthedocs-preview anemoi-utils end -->