### PR TITLE
feat: review handling of secret settings

### DIFF
--- a/src/anemoi/utils/cli.py
+++ b/src/anemoi/utils/cli.py
@@ -41,6 +41,7 @@ class Command:
     """Base class for commands."""
 
     accept_unknown_args = False
+    aliases: list[str] = []
 
     def check(self, parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
         """Check the command arguments."""
@@ -97,7 +98,9 @@ def make_parser(description: str, commands: dict[str, Command]) -> argparse.Argu
 
     subparsers = parser.add_subparsers(help="commands:", dest="command")
     for name, command in commands.items():
-        command_parser = subparsers.add_parser(name, description=command.__doc__, help=command.__doc__)
+        command_parser = subparsers.add_parser(
+            name, aliases=command.aliases, description=command.__doc__, help=command.__doc__
+        )
         command.add_arguments(command_parser)
 
     return parser
@@ -236,7 +239,12 @@ def cli_main(
         parser.print_help()
         return
 
-    cmd = commands[args.command]
+    cmd = commands.get(args.command)
+    if cmd is None:
+        # `args.command` may be an alias; look it up among the registered commands.
+        cmd = next((c for c in commands.values() if args.command in c.aliases), None)
+    if cmd is None:
+        parser.error(f"Unknown command: {args.command}")
 
     if args.rich:
         from .logs import get_rich_handler

--- a/src/anemoi/utils/commands/settings.py
+++ b/src/anemoi/utils/commands/settings.py
@@ -28,7 +28,7 @@ class Settings(Command):
         command_parser : ArgumentParser
             The argument parser to which the arguments will be added.
         """
-        command_parser.add_argument("--path", help="Print path to settings file")
+        command_parser.add_argument("--path", action="store_true", help="Print path to settings file")
 
     def run(self, args: Namespace) -> None:
         """Execute the command with the provided arguments.

--- a/src/anemoi/utils/commands/settings.py
+++ b/src/anemoi/utils/commands/settings.py
@@ -15,8 +15,10 @@ from ..settings import SETTINGS
 from . import Command
 
 
-class Config(Command):
-    """Handle configuration related commands."""
+class Settings(Command):
+    """Handle settings related commands."""
+
+    aliases = ["config"]
 
     def add_arguments(self, command_parser: ArgumentParser) -> None:
         """Add arguments to the command parser.
@@ -26,7 +28,7 @@ class Config(Command):
         command_parser : ArgumentParser
             The argument parser to which the arguments will be added.
         """
-        command_parser.add_argument("--path", help="Print path to config file")
+        command_parser.add_argument("--path", help="Print path to settings file")
 
     def run(self, args: Namespace) -> None:
         """Execute the command with the provided arguments.
@@ -43,4 +45,4 @@ class Config(Command):
             print(SETTINGS.model_dump_json(indent=4))
 
 
-command = Config
+command = Settings

--- a/src/anemoi/utils/settings.py
+++ b/src/anemoi/utils/settings.py
@@ -92,9 +92,6 @@ def _ensure_secure_file(path: Path) -> None:
 
 
 _WILDCARD = "*"
-# Top-level boolean key that can be set in the secrets file to opt out of
-# dropping non-secret keys found there. Accepts hyphen or underscore spelling.
-_KEEP_EXTRAS_KEYS = ("keep-extra-settings", "keep_extra_settings")
 # A SecretTree is a nested dict where leaves are True (SecretStr) and inner
 # nodes are sub-trees keyed by underscore-normalised field name. The special
 # key "*" represents typed extras (`__pydantic_extra__: dict[str, Model]`).
@@ -150,18 +147,6 @@ def _collect_secret_paths(model_cls: type, seen: frozenset[type] = frozenset()) 
     return tree
 
 
-def _flatten_tree(d: DataTree, prefix: str = "") -> list[str]:
-    """Flatten a DataTree into a list of dotted path strings."""
-    out: list[str] = []
-    for k, v in d.items():
-        path = f"{prefix}{k}"
-        if isinstance(v, dict):
-            out.extend(_flatten_tree(v, path + "."))
-        else:
-            out.append(path)
-    return out
-
-
 def _deep_merge(base: DataTree, extra: DataTree) -> DataTree:
     """Recursively merge *extra* into *base*, returning a new dict.
 
@@ -215,77 +200,49 @@ def convert_to_secret(
     raise ValueError(f"Unsupported type for secret value: {type(val)}")
 
 
-class AnemoiSecretsSource(PydanticBaseSettingsSource):
-    """Loads SecretStr-typed fields from secured TOML/YAML files."""
+class AnemoiConfigFileSource(PydanticBaseSettingsSource):
+    """Loads settings from a TOML/YAML config file pair.
 
-    def __init__(self, settings_cls: type[BaseSettings]) -> None:
+    Secret (``SecretStr``) values may live in *any* settings file, provided
+    that file has mode ``0600``. A file that contains no secrets has no
+    permission requirement. There is therefore no need to partition secret and
+    non-secret keys into separate files: keys may go anywhere as long as any
+    file holding a secret is mode ``0600``.
+    """
+
+    def __init__(
+        self,
+        settings_cls: type[BaseSettings],
+        toml_file: Path,
+        yaml_file: Path,
+    ) -> None:
         super().__init__(settings_cls)
-        self._toml_path = ANEMOI_SETTINGS_FILE_LOCATION.with_suffix(".secrets.toml")
-        self._yaml_path = ANEMOI_SETTINGS_FILE_LOCATION.with_suffix(".secrets.yaml")
-
-        _ensure_secure_file(self._toml_path)
-        _ensure_secure_file(self._yaml_path)
-
-        self._toml_source = TomlConfigSettingsSource(settings_cls, toml_file=self._toml_path)
-        self._yaml_source = YamlConfigSettingsSource(settings_cls, yaml_file=self._yaml_path)
+        self._toml_file = toml_file
+        self._yaml_file = yaml_file
+        self._toml_source = TomlConfigSettingsSource(settings_cls, toml_file=toml_file)
+        self._yaml_source = YamlConfigSettingsSource(settings_cls, yaml_file=yaml_file)
         self._secret_tree = _collect_secret_paths(settings_cls)
 
     def get_field_value(self, field: Any, field_name: str) -> tuple[Any, str, bool]:
         raise NotImplementedError
 
-    def __call__(self) -> dict[str, Any]:
-        data: dict[str, Any] = {**self._yaml_source(), **self._toml_source()}
-        if not data:
-            return {}
-        keep_extras = False
-        for key in _KEEP_EXTRAS_KEYS:
-            if key in data:
-                keep_extras = bool(data.pop(key))
-        secret, rest = _split_secrets(data, self._secret_tree)
-        result = convert_to_secret(secret) if secret else {}
-        if rest:
-            if keep_extras:
-                result = _deep_merge(result, rest)
-            else:
-                logger.warning(
-                    "Ignoring non-secret keys in secrets file(s): %s. Move these to %s, "
-                    "or set `keep_extra_settings = true` in the secrets file to keep them.",
-                    sorted(_flatten_tree(rest)),
-                    self._toml_path.with_name(self._toml_path.name.replace(".secrets", "")),
-                )
-        return result
-
-
-class AnemoiNonSecretsSource(PydanticBaseSettingsSource):
-    """Loads non-secret fields from TOML/YAML files; rejects any SecretStr leaves."""
-
-    def __init__(self, settings_cls: type[BaseSettings]) -> None:
-        super().__init__(settings_cls)
-        self._toml_source = TomlConfigSettingsSource(
-            settings_cls,
-            toml_file=ANEMOI_SETTINGS_FILE_LOCATION.with_suffix(".toml"),
-        )
-        self._yaml_source = YamlConfigSettingsSource(
-            settings_cls,
-            yaml_file=ANEMOI_SETTINGS_FILE_LOCATION.with_suffix(".yaml"),
-        )
-        self._secret_tree = _collect_secret_paths(settings_cls)
-
-    def get_field_value(self, field: Any, field_name: str) -> tuple[Any, str, bool]:
-        raise NotImplementedError
-
-    def __call__(self) -> dict[str, Any]:
-        data: dict[str, Any] = {**self._yaml_source(), **self._toml_source()}
+    def _load(self, path: Path, source: PydanticBaseSettingsSource) -> dict[str, Any]:
+        data: dict[str, Any] = source()
         if not data:
             return {}
         secret, rest = _split_secrets(data, self._secret_tree)
-        if secret:
-            stem = ANEMOI_SETTINGS_FILE_LOCATION.stem
-            raise ValueError(
-                f"Secret keys {sorted(_flatten_tree(secret))} found in non-secret config files; "
-                f"move them to the {stem}.secrets.toml/{stem}.secrets.yaml file (mode 0600)."
-            )
-        return rest
+        if not secret:
+            return rest
+        # Any file holding secrets must be locked down.
+        _ensure_secure_file(path)
+        return _deep_merge(convert_to_secret(secret), rest)
+
+    def __call__(self) -> dict[str, Any]:
+        # TOML takes precedence over YAML for the same key.
+        return {
+            **self._load(self._yaml_file, self._yaml_source),
+            **self._load(self._toml_file, self._toml_source),
+        }
 
 
 class AnemoiSettings(BaseSettings):
@@ -296,12 +253,15 @@ class AnemoiSettings(BaseSettings):
     (default: ``~/.config/anemoi/settings.toml``).
 
     The main settings file can be in either TOML or YAML format; the extension
-    is ignored.  ``SecretStr``-typed fields should be placed in a separate
-    secrets file with the same name but suffixed with ``.secrets``
-    (e.g. ``settings.secrets.toml``) and must have permissions set to ``0600``.
-    Non-secret fields will be ignored if found in the secrets file, and secret
-    fields will be rejected if found in the main settings file, to encourage
-    proper separation of concerns.
+    is ignored. Keys may be placed in any settings file, secret or not: there
+    is no requirement to partition secret and non-secret keys into separate
+    files. The only rule is that **any file containing a ``SecretStr`` value
+    must have permissions ``0600``**; a secret found in a file that is readable
+    by group or others is a fatal error (:class:`PermissionError`).
+
+    An optional secrets file with the same name but suffixed with ``.secrets``
+    (e.g. ``settings.secrets.toml``) is also read. It is the natural place to
+    keep secrets when the main settings file must stay readable by others.
 
     **Note:** Init kwargs are intentionally disabled as a source of settings.
 
@@ -309,8 +269,8 @@ class AnemoiSettings(BaseSettings):
 
     1. Environment variables (with prefix ``ANEMOI_SETTINGS_`` and keys in
        upper case with underscores)
-    2. Secret values from the ``.secrets.(toml|yaml)`` file
-    3. Non-secret values from the ``.(toml|yaml)`` file
+    2. Values from the ``.secrets.(toml|yaml)`` file
+    3. Values from the ``.(toml|yaml)`` file
     4. Default values defined in the ``AnemoiSettings`` class and its nested
        models
     """
@@ -353,12 +313,21 @@ class AnemoiSettings(BaseSettings):
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
+        location = ANEMOI_SETTINGS_FILE_LOCATION
         return (
-            # init_settings, # Disable init kwargs to enforce separation of secrets/non-secrets and encourage use of env vars for overrides
+            # init_settings, # Disable init kwargs to encourage use of env vars for overrides
             env_settings,
             dotenv_settings,
-            AnemoiSecretsSource(settings_cls),
-            AnemoiNonSecretsSource(settings_cls),
+            AnemoiConfigFileSource(
+                settings_cls,
+                toml_file=location.with_suffix(".secrets.toml"),
+                yaml_file=location.with_suffix(".secrets.yaml"),
+            ),
+            AnemoiConfigFileSource(
+                settings_cls,
+                toml_file=location.with_suffix(".toml"),
+                yaml_file=location.with_suffix(".yaml"),
+            ),
         )
 
 

--- a/src/anemoi/utils/settings.py
+++ b/src/anemoi/utils/settings.py
@@ -11,6 +11,7 @@
 import logging
 import os
 import shutil
+import threading
 from importlib import resources
 from pathlib import Path
 from typing import Any
@@ -79,15 +80,16 @@ def copy_default_settings(dest: Path | None = None, *, overwrite: bool = False) 
     return dest
 
 
-def _ensure_secure_file(path: Path) -> None:
-    """Verify a secrets file is not world/group readable (POSIX only)."""
+def _ensure_secure_file(path: Path, secret_keys: list[str] | None = None) -> None:
+    """Verify a file holding secrets is not world/group readable (POSIX only)."""
     if os.name != "posix" or not path.exists():
         return
     mode = path.stat().st_mode & 0o777
     if mode != _SECRETS_FILE_MODE:
+        keys = f" ({', '.join(secret_keys)})" if secret_keys else ""
         raise PermissionError(
-            f"Secrets file {path} must have permissions {oct(_SECRETS_FILE_MODE)}; got {oct(mode)}. "
-            f"Run: chmod 600 {path}"
+            f"Secrets found in {path}{keys}: this file must have permissions "
+            f"{oct(_SECRETS_FILE_MODE)}; got {oct(mode)}. Run: chmod 600 {path}"
         )
 
 
@@ -163,6 +165,18 @@ def _deep_merge(base: DataTree, extra: DataTree) -> DataTree:
     return out
 
 
+def _flatten_tree(d: DataTree, prefix: str = "") -> list[str]:
+    """Flatten a DataTree into a sorted list of dotted path strings."""
+    out: list[str] = []
+    for k, v in d.items():
+        path = f"{prefix}{k}"
+        if isinstance(v, dict):
+            out.extend(_flatten_tree(v, path + "."))
+        else:
+            out.append(path)
+    return sorted(out)
+
+
 def _split_secrets(data: DataTree, tree: SecretTree) -> tuple[DataTree, DataTree]:
     """Partition *data* into (secret_part, non_secret_part) using *tree*."""
     secret: DataTree = {}
@@ -234,7 +248,7 @@ class AnemoiConfigFileSource(PydanticBaseSettingsSource):
         if not secret:
             return rest
         # Any file holding secrets must be locked down.
-        _ensure_secure_file(path)
+        _ensure_secure_file(path, _flatten_tree(secret))
         return _deep_merge(convert_to_secret(secret), rest)
 
     def __call__(self) -> dict[str, Any]:
@@ -337,6 +351,9 @@ SETTINGS = AnemoiSettings()
 Use `AnemoiSettings()` to create separate instances if needed, but these will be runtime specific.
 """
 
+_SETTINGS_LOCK = threading.Lock()
+"""Guards reassignment of the global :data:`SETTINGS` instance."""
+
 try:
     copy_default_settings()  # Ensure the defaults file is present on disk for users to copy from
 except Exception as e:
@@ -349,4 +366,5 @@ def reload_settings():
     Is run in-place on the global SETTINGS instance.
     """
     global SETTINGS
-    SETTINGS = AnemoiSettings()
+    with _SETTINGS_LOCK:
+        SETTINGS = AnemoiSettings()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -256,7 +256,7 @@ class TestEnvVarOverrides:
 
 
 class TestSecretsSeparation:
-    """Secrets and non-secrets must live in separate files."""
+    """Secrets may live in any file, as long as that file is mode 0600."""
 
     def test_secrets_loaded_from_secrets_file(self, isolated_settings):
         """SecretStr fields in the secrets file are loaded."""
@@ -270,28 +270,42 @@ class TestSecretsSeparation:
         assert isinstance(s.object_storage.access_key_id, SecretStr)
         assert s.object_storage.access_key_id.get_secret_value() == "AKIAIOSFODNN7EXAMPLE"
 
-    def test_secrets_in_config_file_are_rejected(self, isolated_settings):
-        """Putting SecretStr fields in the main config file should raise."""
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permissions only")
+    def test_secrets_in_config_file_allowed_when_secure(self, isolated_settings):
+        """SecretStr fields in the main config file are accepted if it is 0600."""
         isolated_settings.toml.write_text(textwrap.dedent("""\
                 [object-storage]
                 access_key_id = "AKIAIOSFODNN7EXAMPLE"
             """))
-        with pytest.raises(ValueError, match="[Ss]ecret"):
+        isolated_settings.toml.chmod(0o600)
+        s = isolated_settings.load()
+        assert s.object_storage.access_key_id.get_secret_value() == "AKIAIOSFODNN7EXAMPLE"
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX permissions only")
+    def test_secrets_in_world_readable_config_file_raise(self, isolated_settings):
+        """A secret in a world-readable config file is a fatal error."""
+        isolated_settings.toml.write_text(textwrap.dedent("""\
+                [object-storage]
+                access_key_id = "AKIAIOSFODNN7EXAMPLE"
+            """))
+        isolated_settings.toml.chmod(0o644)
+        with pytest.raises(PermissionError, match="0o600"):
             isolated_settings.load()
 
-    def test_non_secrets_in_secrets_file_are_ignored(self, isolated_settings):
-        """Non-secret keys in the secrets file should be silently ignored."""
+    def test_non_secrets_in_secrets_file_are_loaded(self, isolated_settings):
+        """Non-secret keys in the secrets file are loaded, not partitioned away."""
         isolated_settings.secrets_toml.write_text(textwrap.dedent("""\
                 [paramdb]
-                default_origin = "should-be-ignored"
+                default_origin = "from-secrets-file"
 
                 [object-storage]
                 access_key_id = "AKIAEXAMPLE"
             """))
         isolated_settings.secrets_toml.chmod(0o600)
         s = isolated_settings.load()
-        # The non-secret key should NOT have been applied
-        assert s.paramdb.default_origin != "should-be-ignored"
+        # Keys may live anywhere; the non-secret key is applied.
+        assert s.paramdb.default_origin == "from-secrets-file"
+        assert s.object_storage.access_key_id.get_secret_value() == "AKIAEXAMPLE"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Allow secret/non secret settings key to live in any config file as long as the files are mode 0600. Change the cli subcommand from "config" to "settings". Warning: "keep-extra-settings" flag is gone.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
