### PR TITLE
feat: fix timezone corner case

### DIFF
--- a/src/anemoi/utils/dates.py
+++ b/src/anemoi/utils/dates.py
@@ -41,6 +41,12 @@ def normalise_frequency(frequency: int | str) -> int:
 def _no_time_zone(date: datetime.datetime) -> datetime.datetime:
     """Remove time zone information from a date.
 
+    An explicitly-offset datetime is first converted to UTC, so its instant
+    is preserved rather than its wall-clock reading; the conversion is a pure
+    function of the datetime's own offset and never consults the local clock,
+    so the result is reproducible across machines. A naive datetime already
+    means UTC by convention and is returned unchanged.
+
     Parameters
     ----------
     date : datetime.datetime
@@ -52,6 +58,8 @@ def _no_time_zone(date: datetime.datetime) -> datetime.datetime:
         The datetime object without time zone information.
     """
 
+    if date.tzinfo is not None:
+        date = date.astimezone(datetime.timezone.utc)
     return date.replace(tzinfo=None)
 
 


### PR DESCRIPTION
I found the issue when updating the script to write anemoi-datasets recipe, when writing dates, I had a confusion between timezone aware and timezone-unware(i.e. naive) dates.

Claude generated a fix and this message below. It makes sense to me but I am concerned about other anemoi packages.


**Problem**

`_no_time_zone` (used by `as_datetime`, the canonical date parser across the  anemoi stack) previously did `date.replace(tzinfo=None)` unconditionally. For  an offset-aware datetime this **drops** the offset instead of converting  through it, keeping the wall-clock reading rather than the instant:

  ```python
  as_datetime("1979-01-01T00:00:00+02:00")  # was 1979-01-01 00:00:00  (wrong)
                                             # now 1978-12-31 22:00:00  (UTC)
```

**Fix**

  Convert to UTC first when the datetime carries an offset, then strip:

```
  if date.tzinfo is not None:
      date = date.astimezone(datetime.timezone.utc)
  return date.replace(tzinfo=None)
```

**Why this is safe / reproducible**

  - .astimezone() is only called when tzinfo is present, so the conversion  is a pure function of the value's own offset and never consults the local   clock — results are identical on any machine regardless of $TZ.
  - Naive inputs are returned unchanged (naive = UTC by convention).
  - Z/UTC inputs are unchanged from before (00:00Z → 00:00).
  - Only genuinely non-UTC-offset inputs change behaviour — and their previous   behaviour was incorrect.

**Testing**

  - tests/test_dates.py passes.
  - Verified naive / Z / +02:00 give identical results under   TZ=UTC, TZ=Europe/Madrid, TZ=America/New_York.
  
***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
