### PR TITLE
fix: remove alias generator

### DIFF
--- a/src/anemoi/utils/settings.py
+++ b/src/anemoi/utils/settings.py
@@ -293,7 +293,6 @@ class AnemoiSettings(BaseSettings):
         env_prefix="ANEMOI_SETTINGS_",
         env_nested_delimiter="__",
         extra="ignore",
-        alias_generator=lambda key: key.replace("_", "-"),
         serialize_by_alias=True,
         populate_by_name=True,
     )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -251,6 +251,38 @@ class TestEnvVarOverrides:
 
 
 # ---------------------------------------------------------------------------
+# Environment prefix isolation (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestEnvPrefixIsolation:
+    """Only ``ANEMOI_SETTINGS_``-prefixed env vars may configure settings.
+
+    Regression guard: a bare environment variable whose name collides with a
+    top-level field (e.g. ``DATASETS``) must be ignored.
+    """
+
+    def test_bare_field_named_env_var_does_not_break_loading(self, isolated_settings):
+        """A bare ``DATASETS`` (non-JSON) must not raise and must not set the field."""
+        s = isolated_settings.load(DATASETS="/scratch/some/path")
+        assert s.datasets.path == []  # unchanged default, bare var ignored
+
+    def test_bare_field_named_env_var_does_not_override_file(self, isolated_settings):
+        """A bare env var must not override a value coming from the config file."""
+        isolated_settings.toml.write_text(textwrap.dedent("""\
+                [paramdb]
+                default_origin = "destine"
+            """))
+        s = isolated_settings.load(PARAMDB="not-json")
+        assert s.paramdb.default_origin == "destine"
+
+    def test_prefixed_env_var_still_configures_field(self, isolated_settings):
+        """The documented ``ANEMOI_SETTINGS_`` prefix must remain effective."""
+        s = isolated_settings.load(ANEMOI_SETTINGS_DATASETS__IGNORE_NAMING_CONVENTIONS="1")
+        assert s.datasets.ignore_naming_conventions is True
+
+
+# ---------------------------------------------------------------------------
 # Secrets separation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description
A  DATASETS environment variable was being misread as the datasets setting and JSON-parsed, crashing anemoi-utils (and thus training) on import — because the `alias_generator` disabled the `ANEMOI_SETTINGS_` env prefix.

A minimal fix is to simply remove `alias_generator`. This is safe because the only thing it did usefully was kebab-case the settings file section names — and the one section that actually needs that (object-storage) already declares alias="object-storage" explicitly, so it keeps working. The other four fields (datasets, paramdb, registry, utils) are single words, so the generator gave them identity aliases whose only effect was accidentally stripping `env_prefix`. Removing it drops nothing real and restores `ANEMOI_SETTINGS_*` as the documented env interface.

## What problem does this change solve?
bugfix for #331 

##  Additional notes ##
Coded with the help of an agent. Test added.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
