### PR TITLE
feat(settings): Reject old object-storage entries and hide input in errors

### DIFF
--- a/src/anemoi/utils/settings.py
+++ b/src/anemoi/utils/settings.py
@@ -295,6 +295,7 @@ class AnemoiSettings(BaseSettings):
         extra="ignore",
         serialize_by_alias=True,
         populate_by_name=True,
+        hide_input_in_errors=True,  # prevent secrets from leaking on validation errors
     )
 
     ## ---------- Setting fields ---------- ##

--- a/src/anemoi/utils/settings_schema/object_storage.py
+++ b/src/anemoi/utils/settings_schema/object_storage.py
@@ -73,6 +73,18 @@ class ObjectStorageBucketConfig(AnemoiBaseSettingsSchema):
         _reject_mixed_backends(self)
         return self
 
+    @model_validator(mode="before")
+    def _reject_old_entries(cls, values: dict) -> dict:
+        errors = []
+        for key in values:
+            if key.startswith("aws_"):
+                errors.append(
+                    f"[object-storage] entry `{key}` is no longer supported. Replace it with `{key.removeprefix('aws_')}`."
+                )
+        if errors:
+            raise ValueError("\n" + "\n".join(errors))
+        return values
+
     def get(self, key: str, default: str | None = None) -> str | None:
         """Get a configuration value with fallback to the global setting."""
         warnings.warn(


### PR DESCRIPTION
## Description
If someone (me) still has the old object-storage entries like `aws_secret_access_key` in their settings file, the settings would fail to validate and leak the secret value in the output log:

```
object-storage.aws_access_key_id
  Input should be a valid dictionary or instance of ObjectStorageBucketConfig [type=model_type, 
  input_value='SECRET PRINTED HERE', input_type=str]
    For further information visit https://errors.pydantic.dev/2.13/v/model_type
object-storage.aws_secret_access_key
  Input should be a valid dictionary or instance of ObjectStorageBucketConfig [type=model_type, 
  input_value='SECRET PRINTED HERE', input_type=str]
    For further information visit https://errors.pydantic.dev/2.13/v/model_type
```

- Add a validator to object_storage to throw a better error on those old fields and tell users to update their config
- Prevent secrets from leaking by not printing any input values on validation errors. This might make validation errors a bit more harder to interpret, but I think that's an acceptable trade-off. 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
